### PR TITLE
chore: add default CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hotdata-dev/engineers


### PR DESCRIPTION
Default CODEOWNERS so new PRs auto-request @hotdata-dev/engineers for review, matching the org-wide convention from the codeowners-sync job.

Opened by hand because the sync job skips forks — but this fork has active first-party development (merged PRs from three team members), so it should get the same review auto-assignment as everything else. Cost vs upstream is a one-file diff.

Note: the @hotdata-dev/engineers team currently has **no access to this repo**, so this file is inert until someone with org admin runs:

```sh
gh api -X PUT orgs/hotdata-dev/teams/engineers/repos/hotdata-dev/liquid-cache -f permission=push
```