### PR TITLE
fix(join): keep dynamic filters off null-aware anti join probe sides

### DIFF
--- a/src/datafusion-client/src/lib.rs
+++ b/src/datafusion-client/src/lib.rs
@@ -14,7 +14,6 @@ use datafusion::{
     prelude::*,
 };
 use fastrace_tonic::FastraceClientService;
-use liquid_cache_datafusion::optimizers::NullAwareJoinDynamicFilterGuard;
 pub use optimizer::PushdownOptimizer;
 use tonic::transport::Channel;
 
@@ -125,10 +124,6 @@ impl LiquidCacheClientBuilder {
                 self.cache_server.clone(),
                 self.object_stores.clone(),
             )))
-            // Joins run client-side, and `LiquidCacheClientExec` forwards
-            // pushed filters into the fragment it ships, so the probe side of a
-            // null-aware anti join is reachable here too.
-            .with_physical_optimizer_rule(Arc::new(NullAwareJoinDynamicFilterGuard::new()))
             .build();
         Ok(SessionContext::new_with_state(session_state))
     }

--- a/src/datafusion-client/src/lib.rs
+++ b/src/datafusion-client/src/lib.rs
@@ -14,6 +14,7 @@ use datafusion::{
     prelude::*,
 };
 use fastrace_tonic::FastraceClientService;
+use liquid_cache_datafusion::optimizers::NullAwareJoinDynamicFilterGuard;
 pub use optimizer::PushdownOptimizer;
 use tonic::transport::Channel;
 
@@ -124,6 +125,10 @@ impl LiquidCacheClientBuilder {
                 self.cache_server.clone(),
                 self.object_stores.clone(),
             )))
+            // Joins run client-side, and `LiquidCacheClientExec` forwards
+            // pushed filters into the fragment it ships, so the probe side of a
+            // null-aware anti join is reachable here too.
+            .with_physical_optimizer_rule(Arc::new(NullAwareJoinDynamicFilterGuard::new()))
             .build();
         Ok(SessionContext::new_with_state(session_state))
     }

--- a/src/datafusion-local/src/lib.rs
+++ b/src/datafusion-local/src/lib.rs
@@ -13,7 +13,7 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use liquid_cache::cache::squeeze_policies::{SqueezePolicy, TranscodeSqueezeEvict};
 use liquid_cache::cache::{AlwaysHydrate, HydrationPolicy, default_max_memory_bytes};
 use liquid_cache::cache_policies::{CachePolicy, LiquidPolicy};
-use liquid_cache_datafusion::optimizers::{LocalModeOptimizer, NoDynamicFiltersForNullAwareJoins};
+use liquid_cache_datafusion::optimizers::{LocalModeOptimizer, NullAwareJoinFilterGuard};
 use liquid_cache_datafusion::{
     LiquidCacheParquet, LiquidCacheParquetRef, VariantGetUdf, VariantPretty, VariantToJsonUdf,
 };
@@ -232,11 +232,10 @@ impl LiquidCacheLocalBuilder {
         let state = datafusion::execution::SessionStateBuilder::new()
             .with_config(config)
             .with_default_features()
-            // Wrap the stock rules so none of them can attach a dynamic filter
-            // to a plan holding a null-aware anti join, then append ours, which
-            // runs last.
-            .with_physical_optimizer_rules(NoDynamicFiltersForNullAwareJoins::wrap_default_rules())
             .with_physical_optimizer_rule(Arc::new(optimizer))
+            // Appended, so it runs after the filter-pushdown rules that attach
+            // the dynamic filters it clears.
+            .with_physical_optimizer_rule(Arc::new(NullAwareJoinFilterGuard::new()))
             .build();
 
         let ctx = SessionContext::new_with_state(state);

--- a/src/datafusion-local/src/lib.rs
+++ b/src/datafusion-local/src/lib.rs
@@ -13,7 +13,7 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use liquid_cache::cache::squeeze_policies::{SqueezePolicy, TranscodeSqueezeEvict};
 use liquid_cache::cache::{AlwaysHydrate, HydrationPolicy, default_max_memory_bytes};
 use liquid_cache::cache_policies::{CachePolicy, LiquidPolicy};
-use liquid_cache_datafusion::optimizers::LocalModeOptimizer;
+use liquid_cache_datafusion::optimizers::{LocalModeOptimizer, NullAwareJoinDynamicFilterGuard};
 use liquid_cache_datafusion::{
     LiquidCacheParquet, LiquidCacheParquetRef, VariantGetUdf, VariantPretty, VariantToJsonUdf,
 };
@@ -233,6 +233,10 @@ impl LiquidCacheLocalBuilder {
             .with_config(config)
             .with_default_features()
             .with_physical_optimizer_rule(Arc::new(optimizer))
+            // Both rules are appended, so they run after the filter-pushdown
+            // rules — which is what the guard needs to see the join's dynamic
+            // filter already attached.
+            .with_physical_optimizer_rule(Arc::new(NullAwareJoinDynamicFilterGuard::new()))
             .build();
 
         let ctx = SessionContext::new_with_state(state);

--- a/src/datafusion-local/src/lib.rs
+++ b/src/datafusion-local/src/lib.rs
@@ -13,7 +13,9 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use liquid_cache::cache::squeeze_policies::{SqueezePolicy, TranscodeSqueezeEvict};
 use liquid_cache::cache::{AlwaysHydrate, HydrationPolicy, default_max_memory_bytes};
 use liquid_cache::cache_policies::{CachePolicy, LiquidPolicy};
-use liquid_cache_datafusion::optimizers::{LocalModeOptimizer, NullAwareJoinFilterGuard};
+use liquid_cache_datafusion::optimizers::{
+    LocalModeOptimizer, NullAwareJoinFilterGuard, NullAwareValueFilterGuard,
+};
 use liquid_cache_datafusion::{
     LiquidCacheParquet, LiquidCacheParquetRef, VariantGetUdf, VariantPretty, VariantToJsonUdf,
 };
@@ -232,9 +234,12 @@ impl LiquidCacheLocalBuilder {
         let state = datafusion::execution::SessionStateBuilder::new()
             .with_config(config)
             .with_default_features()
+            // Wrapped so no stock rule can create a TopK or aggregate dynamic
+            // filter in a plan holding a null-aware anti join.
+            .with_physical_optimizer_rules(NullAwareValueFilterGuard::wrap_default_rules())
             .with_physical_optimizer_rule(Arc::new(optimizer))
             // Appended, so it runs after the filter-pushdown rules that attach
-            // the dynamic filters it clears.
+            // the join dynamic filters it clears.
             .with_physical_optimizer_rule(Arc::new(NullAwareJoinFilterGuard::new()))
             .build();
 

--- a/src/datafusion-local/src/lib.rs
+++ b/src/datafusion-local/src/lib.rs
@@ -13,7 +13,7 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use liquid_cache::cache::squeeze_policies::{SqueezePolicy, TranscodeSqueezeEvict};
 use liquid_cache::cache::{AlwaysHydrate, HydrationPolicy, default_max_memory_bytes};
 use liquid_cache::cache_policies::{CachePolicy, LiquidPolicy};
-use liquid_cache_datafusion::optimizers::{LocalModeOptimizer, NullAwareJoinDynamicFilterGuard};
+use liquid_cache_datafusion::optimizers::{LocalModeOptimizer, NoDynamicFiltersForNullAwareJoins};
 use liquid_cache_datafusion::{
     LiquidCacheParquet, LiquidCacheParquetRef, VariantGetUdf, VariantPretty, VariantToJsonUdf,
 };
@@ -232,11 +232,11 @@ impl LiquidCacheLocalBuilder {
         let state = datafusion::execution::SessionStateBuilder::new()
             .with_config(config)
             .with_default_features()
+            // Wrap the stock rules so none of them can attach a dynamic filter
+            // to a plan holding a null-aware anti join, then append ours, which
+            // runs last.
+            .with_physical_optimizer_rules(NoDynamicFiltersForNullAwareJoins::wrap_default_rules())
             .with_physical_optimizer_rule(Arc::new(optimizer))
-            // Both rules are appended, so they run after the filter-pushdown
-            // rules — which is what the guard needs to see the join's dynamic
-            // filter already attached.
-            .with_physical_optimizer_rule(Arc::new(NullAwareJoinDynamicFilterGuard::new()))
             .build();
 
         let ctx = SessionContext::new_with_state(state);

--- a/src/datafusion-local/src/tests/mod.rs
+++ b/src/datafusion-local/src/tests/mod.rs
@@ -25,6 +25,7 @@ use crate::LiquidCacheLocalBuilder;
 mod batch_size_alignment;
 mod date_optimizer;
 mod filter_limit;
+mod null_semantics;
 mod page_index;
 mod squeeze;
 mod variants;

--- a/src/datafusion-local/src/tests/null_semantics.rs
+++ b/src/datafusion-local/src/tests/null_semantics.rs
@@ -11,8 +11,8 @@
 //! require it to drop. The bug is in DataFusion's join, not in the cache — a
 //! plain parquet scan is equally wrong, and a `MemTable` (which accepts no
 //! pushdown) is the only thing that answers correctly — but it lands on every
-//! LiquidCache query, so `NoDynamicFiltersForNullAwareJoins` keeps dynamic
-//! filters out of any plan holding a null-aware join. See
+//! LiquidCache query, so `NullAwareJoinFilterGuard` clears the filter from any
+//! join whose filter could reach a null-aware join's probe side. See
 //! <https://github.com/hotdata-dev/liquid-cache/issues/16>.
 //!
 //! The expected values below are plain SQL semantics, not a differential
@@ -237,11 +237,11 @@ async fn joins_of(ctx: &SessionContext, sql: &str) -> Vec<(bool, bool)> {
     out
 }
 
-/// Dynamic filters survive everywhere except in a plan that holds a null-aware
-/// join — there they are suppressed plan-wide, since one join's filter reaches
-/// another's probe side.
+/// The guard is narrow: a join loses its dynamic filter only when that filter
+/// could reach a null-aware join's probe side. A join whose probe subtree holds
+/// no null-aware join keeps its pruning, even in a plan that has one elsewhere.
 #[tokio::test]
-async fn dynamic_filters_suppressed_only_alongside_a_null_aware_join() {
+async fn only_joins_reaching_a_null_aware_probe_side_lose_their_filter() {
     let dir = TempDir::new().unwrap();
     write_outer(dir.path(), &(1000..1109).map(Some).collect::<Vec<_>>());
     write_sub(dir.path(), &[(Some(1), "keep"), (None, "keep")]);
@@ -253,9 +253,10 @@ async fn dynamic_filters_suppressed_only_alongside_a_null_aware_join() {
         joins_of(&ctx, "SELECT t0.a FROM t0 JOIN t2 ON t0.a = t2.a").await,
         vec![(false, true)]
     );
-    // The null-aware join never gets one.
+    // The null-aware join never keeps one.
     assert_eq!(joins_of(&ctx, NOT_IN).await, vec![(true, false)]);
-    // Nor does the join above it, which is the case the plan-scoped guard adds.
+    // Neither does a join above it, whose filter would propagate into the same
+    // probe subtree.
     let nested = format!("SELECT x.a FROM t2 JOIN ({NOT_IN}) x ON t2.a = x.a");
     let joins = joins_of(&ctx, &nested).await;
     assert_eq!(
@@ -265,24 +266,35 @@ async fn dynamic_filters_suppressed_only_alongside_a_null_aware_join() {
     );
     assert!(
         joins.iter().all(|(_, has_filter)| !has_filter),
-        "no join in a null-aware plan may carry a dynamic filter: {joins:?}"
+        "no filter may reach the anti join's probe side: {joins:?}"
+    );
+    // But an unrelated join in the same plan keeps its filter — the guard is
+    // not plan-wide.
+    let sibling = format!("{NOT_IN} UNION ALL SELECT t0.a FROM t0 JOIN t2 ON t0.a = t2.a");
+    let joins = joins_of(&ctx, &sibling).await;
+    assert!(
+        joins.contains(&(true, false)) && joins.contains(&(false, true)),
+        "the sibling join should keep its filter: {joins:?}"
     );
 }
 
-/// A `NOT IN` alongside a range predicate on the same column is still wrong,
-/// and no physical rule can fix it: DataFusion's logical `push_down_filter`
-/// infers the join key and copies `t1.a > ..` into the subquery, dropping the
-/// NULL that makes `NOT IN` never true. Wrong in vanilla DataFusion over a
-/// `MemTable` too, with every dynamic filter disabled. Un-ignore when upstream
-/// stops inferring join-key predicates across a null-aware join.
+/// `NOT IN` alongside *any* predicate on the join key is still wrong, and no
+/// physical rule can fix it: DataFusion's logical `infer_join_predicates`
+/// copies the predicate onto the subquery side — `IS NOT NULL` included —
+/// deleting the NULL that makes `NOT IN` never true. Wrong in vanilla
+/// DataFusion over a `MemTable` too, with every dynamic filter disabled.
+/// Un-ignore when upstream stops inferring join-key predicates across a
+/// null-aware join.
 #[tokio::test]
 #[ignore = "upstream logical-optimizer bug, not reachable from a physical rule"]
-async fn not_in_with_range_predicate_on_the_join_key() {
+async fn not_in_with_any_predicate_on_the_join_key() {
     let dir = TempDir::new().unwrap();
     write_outer(dir.path(), &(1000..1109).map(Some).collect::<Vec<_>>());
     write_sub(dir.path(), &[(Some(1), "keep"), (None, "keep")]);
     let ctx = liquid_ctx(dir.path()).await;
 
-    let sql = format!("SELECT a FROM ({NOT_IN}) x WHERE x.a > 1050");
-    assert_result(&ctx, &sql, &[]).await;
+    for predicate in ["x.a IS NOT NULL", "x.a > 1050", "x.a <> 1050"] {
+        let sql = format!("SELECT a FROM ({NOT_IN}) x WHERE {predicate}");
+        assert_result(&ctx, &sql, &[]).await;
+    }
 }

--- a/src/datafusion-local/src/tests/null_semantics.rs
+++ b/src/datafusion-local/src/tests/null_semantics.rs
@@ -1,0 +1,218 @@
+//! Regression tests for `NOT IN` (null-aware anti join) over cached scans.
+//!
+//! `HashJoinExec` publishes a filter built from its build-side keys
+//! (`key >= min AND key <= max AND key IN (..)`) and pushes it into the
+//! probe-side scan. A null-aware anti join cannot survive that: its answer
+//! depends on what the probe side *contains*, and the filter prunes exactly
+//! the rows that carry the signal — NULL satisfies no comparison, and a probe
+//! side holding no matching keys prunes away to nothing and reads as empty.
+//!
+//! So `a NOT IN (SELECT b ..)` returned the rows SQL tri-state semantics
+//! require it to drop. The bug is in DataFusion's join, not in the cache — a
+//! plain parquet scan is equally wrong, and a `MemTable` (which accepts no
+//! pushdown) is the only thing that answers correctly — but it lands on every
+//! LiquidCache query, so `NullAwareJoinDynamicFilterGuard` detaches the filter
+//! from null-aware joins. See
+//! <https://github.com/hotdata-dev/liquid-cache/issues/16>.
+//!
+//! The expected values below are plain SQL semantics, not a differential
+//! against vanilla DataFusion, because vanilla-over-parquet shares the bug.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{Array, Int64Array, StringArray};
+use arrow::record_batch::RecordBatch;
+use arrow_schema::{DataType, Field, Schema};
+use datafusion::physical_plan::{ExecutionPlan, joins::HashJoinExec};
+use datafusion::prelude::{ParquetReadOptions, SessionConfig, SessionContext};
+use parquet::arrow::ArrowWriter;
+use tempfile::TempDir;
+
+use crate::LiquidCacheLocalBuilder;
+
+/// Outer table `t0`, one nullable `a` column.
+fn write_outer(dir: &Path, vals: &[Option<i64>]) {
+    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, true)]));
+    write(
+        &dir.join("t0.parquet"),
+        schema,
+        vec![Arc::new(Int64Array::from(vals.to_vec()))],
+    );
+}
+
+/// Subquery table `t1`, a nullable `a` keyed by the `s` tag the filter selects on.
+fn write_sub(dir: &Path, vals: &[(Option<i64>, &str)]) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int64, true),
+        Field::new("s", DataType::Utf8, true),
+    ]));
+    let a = Int64Array::from(vals.iter().map(|(a, _)| *a).collect::<Vec<_>>());
+    let s = StringArray::from(vals.iter().map(|(_, s)| *s).collect::<Vec<_>>());
+    write(
+        &dir.join("t1.parquet"),
+        schema,
+        vec![Arc::new(a), Arc::new(s)],
+    );
+}
+
+fn write(path: &Path, schema: Arc<Schema>, cols: Vec<Arc<dyn Array>>) {
+    let batch = RecordBatch::try_new(schema.clone(), cols).unwrap();
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+/// A LiquidCache context over `t0`/`t1` in `dir`.
+async fn liquid_ctx(dir: &Path) -> SessionContext {
+    let cache_dir = dir.join("cache");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    let mut config = SessionConfig::new();
+    config.options_mut().execution.target_partitions = 4;
+    let (ctx, _cache) = LiquidCacheLocalBuilder::new()
+        .with_cache_dir(cache_dir)
+        .build(config)
+        .await
+        .unwrap();
+    for t in ["t0", "t1"] {
+        ctx.register_parquet(
+            t,
+            dir.join(format!("{t}.parquet")).to_str().unwrap(),
+            ParquetReadOptions::default(),
+        )
+        .await
+        .unwrap();
+    }
+    ctx
+}
+
+/// The outer `a` values the query returned, sorted, with NULL as `None`.
+async fn result(ctx: &SessionContext, sql: &str) -> Vec<Option<i64>> {
+    let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+    let mut out: Vec<Option<i64>> = batches
+        .iter()
+        .flat_map(|b| {
+            let col = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .clone();
+            (0..col.len())
+                .map(move |i| (!col.is_null(i)).then(|| col.value(i)))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+/// Asserts `sql` on both the cold and the warm (cache-populated) run, so a
+/// correct answer that only survives one of them still fails.
+async fn assert_result(ctx: &SessionContext, sql: &str, expected: &[Option<i64>]) {
+    for run in ["cold", "warm"] {
+        assert_eq!(result(ctx, sql).await, expected, "{run} run: {sql}");
+    }
+}
+
+const NOT_IN: &str =
+    "SELECT a FROM t0 WHERE t0.a NOT IN (SELECT t1.a FROM t1 WHERE t1.s LIKE 'keep%')";
+
+/// The reported bug. The subquery keeps a NULL, so `NOT IN` is never true and
+/// every outer row must be dropped — the dynamic filter used to prune the
+/// subquery's NULL away, leaving the join to answer as if it had none.
+#[tokio::test]
+async fn probe_side_null_filters_every_row() {
+    let dir = TempDir::new().unwrap();
+    // No subquery value matches an outer value, so only the NULL can decide.
+    write_outer(dir.path(), &(1000..1109).map(Some).collect::<Vec<_>>());
+    write_sub(
+        dir.path(),
+        &[(Some(1), "keep"), (None, "keep"), (Some(2), "drop")],
+    );
+
+    assert_result(&liquid_ctx(dir.path()).await, NOT_IN, &[]).await;
+}
+
+/// The same shape with the NULL filtered out of the subquery: an ordinary anti
+/// join, so every outer row survives. Pins that the guard did not break the
+/// non-NULL path.
+#[tokio::test]
+async fn probe_side_without_null_keeps_every_row() {
+    let dir = TempDir::new().unwrap();
+    write_outer(dir.path(), &(1000..1109).map(Some).collect::<Vec<_>>());
+    write_sub(
+        dir.path(),
+        &[(Some(1), "keep"), (None, "drop"), (Some(2), "keep")],
+    );
+
+    let expected: Vec<Option<i64>> = (1000..1109).map(Some).collect();
+    assert_result(&liquid_ctx(dir.path()).await, NOT_IN, &expected).await;
+}
+
+/// A matching subquery value must still be excluded — the anti join itself has
+/// to keep working, not just its NULL handling.
+#[tokio::test]
+async fn matching_probe_value_is_excluded() {
+    let dir = TempDir::new().unwrap();
+    write_outer(dir.path(), &[Some(1), Some(2), Some(3)]);
+    write_sub(dir.path(), &[(Some(2), "keep"), (Some(3), "drop")]);
+
+    assert_result(&liquid_ctx(dir.path()).await, NOT_IN, &[Some(1), Some(3)]).await;
+}
+
+/// A NULL *outer* key against a non-empty subquery: `NULL NOT IN (1)` is NULL,
+/// so the outer NULL row is dropped while the non-matching row survives. The
+/// dynamic filter used to prune the subquery to nothing here, which made the
+/// join read the probe side as empty and wrongly emit the NULL row.
+#[tokio::test]
+async fn build_side_null_dropped_against_non_empty_probe() {
+    let dir = TempDir::new().unwrap();
+    write_outer(dir.path(), &[None, Some(1000)]);
+    write_sub(dir.path(), &[(Some(1), "keep")]);
+
+    assert_result(&liquid_ctx(dir.path()).await, NOT_IN, &[Some(1000)]).await;
+}
+
+/// `x NOT IN (<empty>)` is vacuously true for every `x`, NULL included.
+#[tokio::test]
+async fn empty_probe_keeps_null_outer_key() {
+    let dir = TempDir::new().unwrap();
+    write_outer(dir.path(), &[None, Some(1000)]);
+    write_sub(dir.path(), &[(Some(1), "drop")]);
+
+    assert_result(&liquid_ctx(dir.path()).await, NOT_IN, &[None, Some(1000)]).await;
+}
+
+fn find_join(plan: &Arc<dyn ExecutionPlan>) -> Option<&HashJoinExec> {
+    if let Some(join) = plan.downcast_ref::<HashJoinExec>() {
+        return Some(join);
+    }
+    plan.children().into_iter().find_map(find_join)
+}
+
+/// The guard is surgical: it detaches the dynamic filter from the null-aware
+/// join only, leaving the pruning optimization in place everywhere else.
+#[tokio::test]
+async fn guard_only_strips_null_aware_joins() {
+    let dir = TempDir::new().unwrap();
+    write_outer(dir.path(), &(1000..1109).map(Some).collect::<Vec<_>>());
+    write_sub(dir.path(), &[(Some(1), "keep"), (None, "keep")]);
+    let ctx = liquid_ctx(dir.path()).await;
+
+    for (sql, null_aware) in [
+        (NOT_IN, true),
+        ("SELECT t0.a FROM t0 JOIN t1 ON t0.a = t1.a", false),
+    ] {
+        let (state, logical) = ctx.sql(sql).await.unwrap().into_parts();
+        let plan = state.create_physical_plan(&logical).await.unwrap();
+        let join = find_join(&plan).expect("query should plan a hash join");
+        assert_eq!(join.null_aware, null_aware, "{sql}");
+        assert_eq!(
+            join.dynamic_filter_expr().is_none(),
+            null_aware,
+            "dynamic filter should be stripped from null-aware joins only: {sql}"
+        );
+    }
+}

--- a/src/datafusion-local/src/tests/null_semantics.rs
+++ b/src/datafusion-local/src/tests/null_semantics.rs
@@ -85,8 +85,8 @@ async fn liquid_ctx(dir: &Path) -> SessionContext {
         .build(config)
         .await
         .unwrap();
-    // `t2` only exists for the tests that write it.
-    for t in ["t0", "t1", "t2"] {
+    // `t2`/`t3` only exist for the tests that write them.
+    for t in ["t0", "t1", "t2", "t3"] {
         let path = dir.join(format!("{t}.parquet"));
         if !path.exists() {
             continue;
@@ -297,4 +297,55 @@ async fn not_in_with_any_predicate_on_the_join_key() {
         let sql = format!("SELECT a FROM ({NOT_IN}) x WHERE {predicate}");
         assert_result(&ctx, &sql, &[]).await;
     }
+}
+
+/// Table `t3`, a second producer to sit beside the anti join under a TopK or
+/// aggregate.
+fn write_sibling(dir: &Path, vals: &[Option<i64>]) {
+    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, true)]));
+    write(
+        &dir.join("t3.parquet"),
+        schema,
+        vec![Arc::new(Int64Array::from(vals.to_vec()))],
+    );
+}
+
+/// A `UNION ALL` sibling drains before the anti join's probe side is read, so
+/// it tightens the shared TopK/aggregate filter that was already pushed into
+/// the still-unread probe scan. `min`/`max` filters and nulls-last TopK filters
+/// drop NULLs outright, so the deciding NULL disappears and `NOT IN` wrongly
+/// contributes rows. Only the anti join's own rows must drop, never the
+/// sibling's.
+#[tokio::test]
+async fn union_all_sibling_cannot_prune_the_probe_side() {
+    // `max`: the anti join's outer values are the larger ones, so a surviving
+    // NOT IN row would win the max.
+    let dir = TempDir::new().unwrap();
+    write_outer(dir.path(), &(1000..20000).map(Some).collect::<Vec<_>>());
+    write_sub(dir.path(), &[(Some(1), "keep"), (None, "keep")]);
+    write_sibling(dir.path(), &(0..900).map(Some).collect::<Vec<_>>());
+    let ctx = liquid_ctx(dir.path()).await;
+    let union = format!("SELECT a FROM t3 UNION ALL {NOT_IN}");
+    assert_result(&ctx, &format!("SELECT max(a) FROM ({union})"), &[Some(899)]).await;
+
+    // `min` and a nulls-last TopK: now the anti join's values are the smaller
+    // ones, so a survivor would win the min and the LIMIT 1.
+    let dir = TempDir::new().unwrap();
+    write_outer(dir.path(), &(1..100).map(Some).collect::<Vec<_>>());
+    write_sub(dir.path(), &[(Some(500), "keep"), (None, "keep")]);
+    write_sibling(dir.path(), &(1000..1900).map(Some).collect::<Vec<_>>());
+    let ctx = liquid_ctx(dir.path()).await;
+    let union = format!("SELECT a FROM t3 UNION ALL {NOT_IN}");
+    assert_result(
+        &ctx,
+        &format!("SELECT min(a) FROM ({union})"),
+        &[Some(1000)],
+    )
+    .await;
+    assert_result(
+        &ctx,
+        &format!("SELECT a FROM ({union}) ORDER BY a ASC LIMIT 1"),
+        &[Some(1000)],
+    )
+    .await;
 }

--- a/src/datafusion-local/src/tests/null_semantics.rs
+++ b/src/datafusion-local/src/tests/null_semantics.rs
@@ -11,8 +11,8 @@
 //! require it to drop. The bug is in DataFusion's join, not in the cache — a
 //! plain parquet scan is equally wrong, and a `MemTable` (which accepts no
 //! pushdown) is the only thing that answers correctly — but it lands on every
-//! LiquidCache query, so `NullAwareJoinDynamicFilterGuard` detaches the filter
-//! from null-aware joins. See
+//! LiquidCache query, so `NoDynamicFiltersForNullAwareJoins` keeps dynamic
+//! filters out of any plan holding a null-aware join. See
 //! <https://github.com/hotdata-dev/liquid-cache/issues/16>.
 //!
 //! The expected values below are plain SQL semantics, not a differential
@@ -30,6 +30,16 @@ use parquet::arrow::ArrowWriter;
 use tempfile::TempDir;
 
 use crate::LiquidCacheLocalBuilder;
+
+/// Table `t2`, used as the far side of a join enclosing the anti join.
+fn write_probe(dir: &Path, vals: &[Option<i64>]) {
+    let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, true)]));
+    write(
+        &dir.join("t2.parquet"),
+        schema,
+        vec![Arc::new(Int64Array::from(vals.to_vec()))],
+    );
+}
 
 /// Outer table `t0`, one nullable `a` column.
 fn write_outer(dir: &Path, vals: &[Option<i64>]) {
@@ -75,14 +85,15 @@ async fn liquid_ctx(dir: &Path) -> SessionContext {
         .build(config)
         .await
         .unwrap();
-    for t in ["t0", "t1"] {
-        ctx.register_parquet(
-            t,
-            dir.join(format!("{t}.parquet")).to_str().unwrap(),
-            ParquetReadOptions::default(),
-        )
-        .await
-        .unwrap();
+    // `t2` only exists for the tests that write it.
+    for t in ["t0", "t1", "t2"] {
+        let path = dir.join(format!("{t}.parquet"));
+        if !path.exists() {
+            continue;
+        }
+        ctx.register_parquet(t, path.to_str().unwrap(), ParquetReadOptions::default())
+            .await
+            .unwrap();
     }
     ctx
 }
@@ -185,34 +196,93 @@ async fn empty_probe_keeps_null_outer_key() {
     assert_result(&liquid_ctx(dir.path()).await, NOT_IN, &[None, Some(1000)]).await;
 }
 
-fn find_join(plan: &Arc<dyn ExecutionPlan>) -> Option<&HashJoinExec> {
-    if let Some(join) = plan.downcast_ref::<HashJoinExec>() {
-        return Some(join);
+/// A join *above* the anti join pushes its own dynamic filter straight through
+/// into the same probe subtree, because `HashJoinExec` reports both sides of a
+/// `LeftAnti` as preserved for pushdown. Detaching only the anti join's own
+/// filter left this wrong, which is why the guard works at plan scope.
+#[tokio::test]
+async fn enclosing_join_cannot_prune_the_probe_side() {
+    let dir = TempDir::new().unwrap();
+    write_outer(dir.path(), &(1000..1109).map(Some).collect::<Vec<_>>());
+    write_sub(dir.path(), &[(Some(1), "keep"), (None, "keep")]);
+    // `t2` matches one outer value, so the enclosing join's filter is narrow
+    // enough to prune the whole subquery file away.
+    write_probe(dir.path(), &[Some(1050)]);
+    let ctx = liquid_ctx(dir.path()).await;
+
+    // The anti join drops every outer row, so the enclosing join has nothing to
+    // match and both orderings must return no rows.
+    for sql in [
+        "SELECT x.a FROM t2 JOIN ({NOT_IN}) x ON t2.a = x.a",
+        "SELECT x.a FROM ({NOT_IN}) x JOIN t2 ON t2.a = x.a",
+    ] {
+        assert_result(&ctx, &sql.replace("{NOT_IN}", NOT_IN), &[]).await;
     }
-    plan.children().into_iter().find_map(find_join)
 }
 
-/// The guard is surgical: it detaches the dynamic filter from the null-aware
-/// join only, leaving the pruning optimization in place everywhere else.
+fn find_joins(plan: &Arc<dyn ExecutionPlan>, out: &mut Vec<(bool, bool)>) {
+    if let Some(join) = plan.downcast_ref::<HashJoinExec>() {
+        out.push((join.null_aware, join.dynamic_filter_expr().is_some()));
+    }
+    for child in plan.children() {
+        find_joins(child, out);
+    }
+}
+
+async fn joins_of(ctx: &SessionContext, sql: &str) -> Vec<(bool, bool)> {
+    let (state, logical) = ctx.sql(sql).await.unwrap().into_parts();
+    let plan = state.create_physical_plan(&logical).await.unwrap();
+    let mut out = Vec::new();
+    find_joins(&plan, &mut out);
+    out
+}
+
+/// Dynamic filters survive everywhere except in a plan that holds a null-aware
+/// join — there they are suppressed plan-wide, since one join's filter reaches
+/// another's probe side.
 #[tokio::test]
-async fn guard_only_strips_null_aware_joins() {
+async fn dynamic_filters_suppressed_only_alongside_a_null_aware_join() {
+    let dir = TempDir::new().unwrap();
+    write_outer(dir.path(), &(1000..1109).map(Some).collect::<Vec<_>>());
+    write_sub(dir.path(), &[(Some(1), "keep"), (None, "keep")]);
+    write_probe(dir.path(), &[Some(1050)]);
+    let ctx = liquid_ctx(dir.path()).await;
+
+    // A plain join keeps its dynamic filter.
+    assert_eq!(
+        joins_of(&ctx, "SELECT t0.a FROM t0 JOIN t2 ON t0.a = t2.a").await,
+        vec![(false, true)]
+    );
+    // The null-aware join never gets one.
+    assert_eq!(joins_of(&ctx, NOT_IN).await, vec![(true, false)]);
+    // Nor does the join above it, which is the case the plan-scoped guard adds.
+    let nested = format!("SELECT x.a FROM t2 JOIN ({NOT_IN}) x ON t2.a = x.a");
+    let joins = joins_of(&ctx, &nested).await;
+    assert_eq!(
+        joins.len(),
+        2,
+        "expected an enclosing join and an anti join"
+    );
+    assert!(
+        joins.iter().all(|(_, has_filter)| !has_filter),
+        "no join in a null-aware plan may carry a dynamic filter: {joins:?}"
+    );
+}
+
+/// A `NOT IN` alongside a range predicate on the same column is still wrong,
+/// and no physical rule can fix it: DataFusion's logical `push_down_filter`
+/// infers the join key and copies `t1.a > ..` into the subquery, dropping the
+/// NULL that makes `NOT IN` never true. Wrong in vanilla DataFusion over a
+/// `MemTable` too, with every dynamic filter disabled. Un-ignore when upstream
+/// stops inferring join-key predicates across a null-aware join.
+#[tokio::test]
+#[ignore = "upstream logical-optimizer bug, not reachable from a physical rule"]
+async fn not_in_with_range_predicate_on_the_join_key() {
     let dir = TempDir::new().unwrap();
     write_outer(dir.path(), &(1000..1109).map(Some).collect::<Vec<_>>());
     write_sub(dir.path(), &[(Some(1), "keep"), (None, "keep")]);
     let ctx = liquid_ctx(dir.path()).await;
 
-    for (sql, null_aware) in [
-        (NOT_IN, true),
-        ("SELECT t0.a FROM t0 JOIN t1 ON t0.a = t1.a", false),
-    ] {
-        let (state, logical) = ctx.sql(sql).await.unwrap().into_parts();
-        let plan = state.create_physical_plan(&logical).await.unwrap();
-        let join = find_join(&plan).expect("query should plan a hash join");
-        assert_eq!(join.null_aware, null_aware, "{sql}");
-        assert_eq!(
-            join.dynamic_filter_expr().is_none(),
-            null_aware,
-            "dynamic filter should be stripped from null-aware joins only: {sql}"
-        );
-    }
+    let sql = format!("SELECT a FROM ({NOT_IN}) x WHERE x.a > 1050");
+    assert_result(&ctx, &sql, &[]).await;
 }

--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -26,7 +26,7 @@ use datafusion::{
     physical_plan::ExecutionPlan,
 };
 
-pub use null_aware_join::NullAwareJoinDynamicFilterGuard;
+pub use null_aware_join::NoDynamicFiltersForNullAwareJoins;
 pub(crate) use squeeze_hint::HintAnalyzer;
 pub use squeeze_hint::SqueezeHintMap;
 

--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -26,7 +26,7 @@ use datafusion::{
     physical_plan::ExecutionPlan,
 };
 
-pub use null_aware_join::NoDynamicFiltersForNullAwareJoins;
+pub use null_aware_join::NullAwareJoinFilterGuard;
 pub(crate) use squeeze_hint::HintAnalyzer;
 pub use squeeze_hint::SqueezeHintMap;
 

--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -1,5 +1,6 @@
 //! Optimizers for the Parquet module
 
+mod null_aware_join;
 mod squeeze_hint;
 
 use std::collections::HashSet;
@@ -25,6 +26,7 @@ use datafusion::{
     physical_plan::ExecutionPlan,
 };
 
+pub use null_aware_join::NullAwareJoinDynamicFilterGuard;
 pub(crate) use squeeze_hint::HintAnalyzer;
 pub use squeeze_hint::SqueezeHintMap;
 

--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -26,7 +26,7 @@ use datafusion::{
     physical_plan::ExecutionPlan,
 };
 
-pub use null_aware_join::NullAwareJoinFilterGuard;
+pub use null_aware_join::{NullAwareJoinFilterGuard, NullAwareValueFilterGuard};
 pub(crate) use squeeze_hint::HintAnalyzer;
 pub use squeeze_hint::SqueezeHintMap;
 

--- a/src/datafusion/src/optimizers/null_aware_join.rs
+++ b/src/datafusion/src/optimizers/null_aware_join.rs
@@ -1,0 +1,87 @@
+//! Strips the build-side dynamic filter from null-aware anti joins.
+//!
+//! `x NOT IN (<subquery>)` plans as a null-aware `LeftAnti` hash join, whose
+//! semantics are driven by what the probe side *contains*, not just by which
+//! probe rows match:
+//!
+//! - a NULL probe key annihilates the output (`x NOT IN (.., NULL, ..)` is
+//!   never true), and
+//! - an empty probe side passes every build row through, NULL keys included.
+//!
+//! `HashJoinExec` also publishes a dynamic filter derived from the build-side
+//! keys (`key >= min AND key <= max AND key IN (..)`) and pushes it into the
+//! probe-side scan. That filter is sound for a plain anti join — a probe row
+//! that cannot match cannot change which build rows are unmatched — but it
+//! destroys both signals above: NULL satisfies no comparison, so probe NULLs
+//! are pruned before the join ever sees them, and a probe side with no
+//! matching keys prunes down to nothing and reads as empty.
+//!
+//! Either way the join answers as if the probe side had no NULLs, so
+//! `SELECT .. WHERE a NOT IN (SELECT b FROM ..)` returns the rows that SQL
+//! tri-state semantics require it to filter out. Upstream guards this only when
+//! the *build* key is nullable, which misses the pruned-probe-NULL case, so the
+//! rule below drops the dynamic filter from every null-aware join.
+//!
+//! The join keeps working without it: the filter is an optional pruning
+//! accelerator, and with it detached the shared expression is never refreshed
+//! from the build side and stays `true`. Only null-aware joins are touched, and
+//! a null-aware join always has a nullable join key (otherwise the planner
+//! would not have asked for null-aware semantics), so there is no case where
+//! this gives up pruning it could soundly have kept.
+//!
+//! See <https://github.com/hotdata-dev/liquid-cache/issues/16>.
+
+use std::sync::Arc;
+
+use datafusion::{
+    common::tree_node::{Transformed, TransformedResult, TreeNode},
+    config::ConfigOptions,
+    error::Result,
+    physical_optimizer::PhysicalOptimizerRule,
+    physical_plan::{ExecutionPlan, joins::HashJoinExec},
+};
+
+/// Physical optimizer rule that removes the build-side dynamic filter from
+/// null-aware anti joins, which cannot read their probe side correctly through
+/// it. See the module docs.
+///
+/// Must run after the filter-pushdown rules that attach the dynamic filter,
+/// i.e. it belongs at the end of the physical optimizer list.
+#[derive(Debug, Default)]
+pub struct NullAwareJoinDynamicFilterGuard;
+
+impl NullAwareJoinDynamicFilterGuard {
+    /// Create the rule.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PhysicalOptimizerRule for NullAwareJoinDynamicFilterGuard {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        plan.transform_up(|node| {
+            let Some(join) = node.downcast_ref::<HashJoinExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            if !join.null_aware || join.dynamic_filter_expr().is_none() {
+                return Ok(Transformed::no(node));
+            }
+            // `reset_state` clears the dynamic filter along with the build-side
+            // future and metrics, none of which carry anything yet at plan time.
+            Ok(Transformed::yes(join.builder().reset_state().build_exec()?))
+        })
+        .data()
+    }
+
+    fn name(&self) -> &str {
+        "NullAwareJoinDynamicFilterGuard"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}

--- a/src/datafusion/src/optimizers/null_aware_join.rs
+++ b/src/datafusion/src/optimizers/null_aware_join.rs
@@ -1,4 +1,4 @@
-//! Keeps dynamic filters away from null-aware anti joins.
+//! Keeps join dynamic filters off the probe side of null-aware anti joins.
 //!
 //! `x NOT IN (<subquery>)` plans as a null-aware `LeftAnti` hash join, and its
 //! answer turns on what the probe side *contains*, not just on which probe rows
@@ -8,73 +8,77 @@
 //!   never true), and
 //! - an empty probe side passes every build row through, NULL keys included.
 //!
-//! A dynamic filter destroys both signals. `HashJoinExec` publishes one built
-//! from its build-side keys (`key >= min AND key <= max AND key IN (..)`) and
-//! pushes it into the probe-side scan; `SortExec`'s TopK and the aggregate
-//! rules publish their own. NULL satisfies no comparison, so probe NULLs are
-//! pruned before the join ever sees them, and a probe side holding no matching
-//! keys prunes away to nothing and reads as empty. Either way the join answers
-//! as if the probe side had no NULLs, and `NOT IN` returns rows that SQL
-//! tri-state semantics require it to drop.
+//! `HashJoinExec` publishes a filter built from its build-side keys
+//! (`key >= min AND key <= max AND key IN (..)`) and pushes it into its probe
+//! side. That is sound for a plain anti join — a probe row that cannot match
+//! cannot change which build rows are unmatched — but it destroys both signals
+//! above: NULL satisfies no comparison, so probe NULLs are pruned before the
+//! join sees them, and a probe side holding no matching keys prunes away to
+//! nothing and reads as empty. Either way the join answers as if the probe side
+//! had no NULLs.
 //!
-//! Removing the filter from the null-aware join alone is not enough: a join
-//! *above* it pushes its own filter straight through into the same probe
-//! subtree, because `HashJoinExec` reports both sides of a `LeftAnti` as
-//! preserved for pushdown ("join key filters can be safely pushed down into
-//! the other side" — true for a plain anti join, false for a null-aware one).
-//! So the guard works at plan scope instead: when the plan contains a
-//! null-aware join at all, every rule runs with dynamic filter pushdown turned
-//! off, and no dynamic filter is created anywhere in that plan.
+//! A join *above* the null-aware one does the same damage with its own filter,
+//! because `HashJoinExec` reports both sides of a `LeftAnti` as preserved for
+//! pushdown, so a parent's filter propagates into the anti join's probe side
+//! too. So this rule clears the dynamic filter of any hash join that is itself
+//! null-aware, or whose probe subtree holds a null-aware join.
 //!
-//! Only static predicate pushdown is left alone, which is sound here — the
-//! probe side *is* the statically filtered subquery, so pruning it by its own
-//! predicate cannot change the answer. The cost is that a query containing a
-//! `NOT IN` gives up dynamic-filter pruning on its other joins too; that is the
-//! granularity the config exposes, and correctness wins.
+//! What it deliberately leaves alone:
 //!
-//! Upstream guards this only when the *build* key is nullable, which misses the
-//! pruned-probe-NULL case entirely. See
+//! - **A join holding the null-aware join on its *build* side.** Its filter
+//!   goes only to its own probe side and can never reach the anti join, so that
+//!   pruning is sound and worth keeping.
+//! - **TopK and aggregate dynamic filters.** Those tighten from the value
+//!   stream *above* the join, and a `LeftAnti` emits nothing until its probe
+//!   side is fully drained, so they cannot prune a probe row before the join
+//!   has counted it. Only the join's own filter comes from the build side,
+//!   which is collected first.
+//! - **Static predicate pushdown.** Not because it is harmless in principle —
+//!   the physical `lr_is_preserved` does route a static parent predicate into a
+//!   `LeftAnti`'s probe side — but because the logical optimizer already copies
+//!   any join-key predicate onto the subquery side before a physical plan
+//!   exists (see below), so nothing is left here to protect. If upstream fixes
+//!   that without fixing physical `lr_is_preserved`, revisit this exemption.
+//!
+//! Two holes remain that no physical rule can reach, both upstream:
+//!
+//! - `infer_join_predicates` copies *any* predicate on the join key onto the
+//!   subquery side, `IS NOT NULL` included, deleting the deciding NULL. So
+//!   `a NOT IN (..) AND <anything on a>` is still wrong — wrong in vanilla
+//!   DataFusion over a `MemTable` with every dynamic filter off.
+//! - With `prefer_hash_join = false` the planner emits a `SortMergeJoinExec`
+//!   and drops `null_aware` outright, leaving no `HashJoinExec` to guard.
+//!
+//! Upstream guards the join's own filter only when the *build* key is nullable,
+//! which misses the pruned-probe-NULL case. See
 //! <https://github.com/hotdata-dev/liquid-cache/issues/16>.
 
 use std::sync::Arc;
 
 use datafusion::{
-    common::tree_node::{TreeNode, TreeNodeRecursion},
+    common::tree_node::{Transformed, TransformedResult, TreeNode, TreeNodeRecursion},
     config::ConfigOptions,
     error::Result,
     physical_optimizer::PhysicalOptimizerRule,
     physical_plan::{ExecutionPlan, joins::HashJoinExec},
 };
 
-/// Wraps a physical optimizer rule so it never gets to attach a dynamic filter
-/// to a plan that contains a null-aware anti join. See the module docs.
+/// Physical optimizer rule that clears the dynamic filter from hash joins whose
+/// filter could reach a null-aware anti join's probe side. See the module docs.
 ///
-/// Wrap every rule in the list — dynamic filters are created inside the
-/// filter-pushdown rules today, but nothing pins them there, and the wrapper is
-/// inert for a plan with no null-aware join.
-#[derive(Debug)]
-pub struct NoDynamicFiltersForNullAwareJoins {
-    inner: Arc<dyn PhysicalOptimizerRule + Send + Sync>,
-}
+/// Must run after the filter-pushdown rules that attach the dynamic filter, so
+/// it belongs at the end of the physical optimizer list.
+#[derive(Debug, Default)]
+pub struct NullAwareJoinFilterGuard;
 
-impl NoDynamicFiltersForNullAwareJoins {
-    /// Wrap `inner`.
-    pub fn new(inner: Arc<dyn PhysicalOptimizerRule + Send + Sync>) -> Self {
-        Self { inner }
-    }
-
-    /// Wrap every rule of DataFusion's default physical optimizer, ready to
-    /// hand to `SessionStateBuilder::with_physical_optimizer_rules`.
-    pub fn wrap_default_rules() -> Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> {
-        datafusion::physical_optimizer::optimizer::PhysicalOptimizer::new()
-            .rules
-            .into_iter()
-            .map(|rule| Arc::new(Self::new(rule)) as Arc<dyn PhysicalOptimizerRule + Send + Sync>)
-            .collect()
+impl NullAwareJoinFilterGuard {
+    /// Create the rule.
+    pub fn new() -> Self {
+        Self
     }
 }
 
-/// Whether `plan` contains a hash join asking for null-aware semantics.
+/// Whether `plan` holds a hash join asking for null-aware semantics.
 fn has_null_aware_join(plan: &Arc<dyn ExecutionPlan>) -> bool {
     let mut found = false;
     // `apply` only fails if the closure does, and this one cannot.
@@ -90,29 +94,39 @@ fn has_null_aware_join(plan: &Arc<dyn ExecutionPlan>) -> bool {
     found
 }
 
-impl PhysicalOptimizerRule for NoDynamicFiltersForNullAwareJoins {
+impl PhysicalOptimizerRule for NullAwareJoinFilterGuard {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        config: &ConfigOptions,
+        _config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        if !has_null_aware_join(&plan) {
-            return self.inner.optimize(plan, config);
-        }
-        let mut config = config.clone();
-        let optimizer = &mut config.optimizer;
-        optimizer.enable_dynamic_filter_pushdown = false;
-        optimizer.enable_join_dynamic_filter_pushdown = false;
-        optimizer.enable_topk_dynamic_filter_pushdown = false;
-        optimizer.enable_aggregate_dynamic_filter_pushdown = false;
-        self.inner.optimize(plan, &config)
+        plan.transform_up(|node| {
+            let Some(join) = node.downcast_ref::<HashJoinExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            if join.dynamic_filter_expr().is_none() {
+                return Ok(Transformed::no(node));
+            }
+            // The join's own filter lands on its probe side, and a parent's
+            // filter propagates down into it, so a null-aware join anywhere in
+            // that subtree is equally exposed.
+            if !join.null_aware && !has_null_aware_join(join.right()) {
+                return Ok(Transformed::no(node));
+            }
+            // `reset_state` clears the dynamic filter along with the build-side
+            // future and metrics, neither of which holds anything at plan time.
+            // The filter expression already attached to the probe scan is then
+            // never refreshed off its initial `true`, so it prunes nothing.
+            Ok(Transformed::yes(join.builder().reset_state().build_exec()?))
+        })
+        .data()
     }
 
     fn name(&self) -> &str {
-        self.inner.name()
+        "NullAwareJoinFilterGuard"
     }
 
     fn schema_check(&self) -> bool {
-        self.inner.schema_check()
+        true
     }
 }

--- a/src/datafusion/src/optimizers/null_aware_join.rs
+++ b/src/datafusion/src/optimizers/null_aware_join.rs
@@ -23,16 +23,25 @@
 //! too. So this rule clears the dynamic filter of any hash join that is itself
 //! null-aware, or whose probe subtree holds a null-aware join.
 //!
-//! What it deliberately leaves alone:
+//! A join holding the null-aware join on its *build* side is left alone: its
+//! filter goes only to its own probe side and can never reach the anti join, so
+//! that pruning is sound and worth keeping. This matters — it is the difference
+//! between pruning an unrelated 400k-row scan to one row and reading all of it.
 //!
-//! - **A join holding the null-aware join on its *build* side.** Its filter
-//!   goes only to its own probe side and can never reach the anti join, so that
-//!   pruning is sound and worth keeping.
-//! - **TopK and aggregate dynamic filters.** Those tighten from the value
-//!   stream *above* the join, and a `LeftAnti` emits nothing until its probe
-//!   side is fully drained, so they cannot prune a probe row before the join
-//!   has counted it. Only the join's own filter comes from the build side,
-//!   which is collected first.
+//! TopK and aggregate filters need the blunter treatment in
+//! [`NullAwareValueFilterGuard`], because they are tightened from the value
+//! stream rather than published at a fixed point in the plan. It is tempting to
+//! argue they are safe — a `LeftAnti` emits nothing until its probe side is
+//! fully drained, so it cannot tighten a threshold against its own unread probe
+//! rows — but that only holds while the anti join is the *sole* producer
+//! feeding the node. Put a second producer under the same TopK or aggregate
+//! (`.. UNION ALL <NOT IN ..>`) and the sibling drains first, tightening the
+//! shared filter that has already been pushed into the still-unread probe scan.
+//! `min()`/`max()` filters and nulls-last TopK filters drop NULLs outright, so
+//! the deciding NULL disappears.
+//!
+//! What both guards deliberately leave alone:
+//!
 //! - **Static predicate pushdown.** Not because it is harmless in principle —
 //!   the physical `lr_is_preserved` does route a static parent predicate into a
 //!   `LeftAnti`'s probe side — but because the logical optimizer already copies
@@ -59,12 +68,18 @@ use datafusion::{
     common::tree_node::{Transformed, TransformedResult, TreeNode, TreeNodeRecursion},
     config::ConfigOptions,
     error::Result,
-    physical_optimizer::PhysicalOptimizerRule,
-    physical_plan::{ExecutionPlan, joins::HashJoinExec},
+    physical_optimizer::{
+        PhysicalOptimizerRule,
+        optimizer::{PhysicalOptimizer, PhysicalOptimizerContext},
+    },
+    physical_plan::{ExecutionPlan, joins::HashJoinExec, operator_statistics::StatisticsRegistry},
 };
 
 /// Physical optimizer rule that clears the dynamic filter from hash joins whose
 /// filter could reach a null-aware anti join's probe side. See the module docs.
+///
+/// Pairs with [`NullAwareValueFilterGuard`], which handles the TopK and
+/// aggregate filters this rule does not touch.
 ///
 /// Must run after the filter-pushdown rules that attach the dynamic filter, so
 /// it belongs at the end of the physical optimizer list.
@@ -128,5 +143,119 @@ impl PhysicalOptimizerRule for NullAwareJoinFilterGuard {
 
     fn schema_check(&self) -> bool {
         true
+    }
+}
+
+/// A [`PhysicalOptimizerContext`] serving an overridden config while passing
+/// everything else — notably the statistics registry — through untouched.
+struct OverriddenConfig<'a> {
+    config: ConfigOptions,
+    inner: &'a dyn PhysicalOptimizerContext,
+}
+
+impl PhysicalOptimizerContext for OverriddenConfig<'_> {
+    fn config_options(&self) -> &ConfigOptions {
+        &self.config
+    }
+
+    fn statistics_registry(&self) -> Option<&StatisticsRegistry> {
+        self.inner.statistics_registry()
+    }
+}
+
+/// Wraps a physical optimizer rule so it cannot create a TopK or aggregate
+/// dynamic filter while the plan holds a null-aware anti join. See the module
+/// docs for why those two cannot be gated per-node the way join filters are.
+///
+/// Unlike the join filters, these are suppressed for the whole plan, so a
+/// `NOT IN` costs the query its TopK and aggregate pruning. The join filters —
+/// the expensive ones — keep their per-node treatment in
+/// [`NullAwareJoinFilterGuard`].
+///
+/// Wrap every rule rather than only the filter-pushdown ones: matching rules by
+/// name would silently stop guarding if upstream renamed one, and the cost of a
+/// short-circuiting walk per rule is immeasurable.
+#[derive(Debug)]
+pub struct NullAwareValueFilterGuard {
+    inner: Arc<dyn PhysicalOptimizerRule + Send + Sync>,
+}
+
+impl NullAwareValueFilterGuard {
+    /// Wrap `inner`.
+    pub fn new(inner: Arc<dyn PhysicalOptimizerRule + Send + Sync>) -> Self {
+        Self { inner }
+    }
+
+    /// Wrap every rule of DataFusion's default physical optimizer, ready for
+    /// `SessionStateBuilder::with_physical_optimizer_rules`.
+    pub fn wrap_default_rules() -> Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> {
+        PhysicalOptimizer::new()
+            .rules
+            .into_iter()
+            .map(|rule| Arc::new(Self::new(rule)) as Arc<dyn PhysicalOptimizerRule + Send + Sync>)
+            .collect()
+    }
+
+    /// The config to run `inner` under, or `None` to pass the caller's through.
+    fn override_for(
+        &self,
+        plan: &Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> Option<ConfigOptions> {
+        let optimizer = &config.optimizer;
+        if !optimizer.enable_topk_dynamic_filter_pushdown
+            && !optimizer.enable_aggregate_dynamic_filter_pushdown
+        {
+            return None;
+        }
+        if !has_null_aware_join(plan) {
+            return None;
+        }
+        let mut config = config.clone();
+        let optimizer = &mut config.optimizer;
+        optimizer.enable_topk_dynamic_filter_pushdown = false;
+        optimizer.enable_aggregate_dynamic_filter_pushdown = false;
+        Some(config)
+    }
+}
+
+impl PhysicalOptimizerRule for NullAwareValueFilterGuard {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match self.override_for(&plan, config) {
+            Some(config) => self.inner.optimize(plan, &config),
+            None => self.inner.optimize(plan, config),
+        }
+    }
+
+    /// Forwarded, not left to the trait default: the planner calls this one, and
+    /// the default would drop `inner`'s own override — and with it the
+    /// statistics registry that drives join-side selection.
+    fn optimize_with_context(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        context: &dyn PhysicalOptimizerContext,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match self.override_for(&plan, context.config_options()) {
+            Some(config) => self.inner.optimize_with_context(
+                plan,
+                &OverriddenConfig {
+                    config,
+                    inner: context,
+                },
+            ),
+            None => self.inner.optimize_with_context(plan, context),
+        }
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn schema_check(&self) -> bool {
+        self.inner.schema_check()
     }
 }

--- a/src/datafusion/src/optimizers/null_aware_join.rs
+++ b/src/datafusion/src/optimizers/null_aware_join.rs
@@ -1,87 +1,118 @@
-//! Strips the build-side dynamic filter from null-aware anti joins.
+//! Keeps dynamic filters away from null-aware anti joins.
 //!
-//! `x NOT IN (<subquery>)` plans as a null-aware `LeftAnti` hash join, whose
-//! semantics are driven by what the probe side *contains*, not just by which
-//! probe rows match:
+//! `x NOT IN (<subquery>)` plans as a null-aware `LeftAnti` hash join, and its
+//! answer turns on what the probe side *contains*, not just on which probe rows
+//! match:
 //!
 //! - a NULL probe key annihilates the output (`x NOT IN (.., NULL, ..)` is
 //!   never true), and
 //! - an empty probe side passes every build row through, NULL keys included.
 //!
-//! `HashJoinExec` also publishes a dynamic filter derived from the build-side
-//! keys (`key >= min AND key <= max AND key IN (..)`) and pushes it into the
-//! probe-side scan. That filter is sound for a plain anti join — a probe row
-//! that cannot match cannot change which build rows are unmatched — but it
-//! destroys both signals above: NULL satisfies no comparison, so probe NULLs
-//! are pruned before the join ever sees them, and a probe side with no
-//! matching keys prunes down to nothing and reads as empty.
+//! A dynamic filter destroys both signals. `HashJoinExec` publishes one built
+//! from its build-side keys (`key >= min AND key <= max AND key IN (..)`) and
+//! pushes it into the probe-side scan; `SortExec`'s TopK and the aggregate
+//! rules publish their own. NULL satisfies no comparison, so probe NULLs are
+//! pruned before the join ever sees them, and a probe side holding no matching
+//! keys prunes away to nothing and reads as empty. Either way the join answers
+//! as if the probe side had no NULLs, and `NOT IN` returns rows that SQL
+//! tri-state semantics require it to drop.
 //!
-//! Either way the join answers as if the probe side had no NULLs, so
-//! `SELECT .. WHERE a NOT IN (SELECT b FROM ..)` returns the rows that SQL
-//! tri-state semantics require it to filter out. Upstream guards this only when
-//! the *build* key is nullable, which misses the pruned-probe-NULL case, so the
-//! rule below drops the dynamic filter from every null-aware join.
+//! Removing the filter from the null-aware join alone is not enough: a join
+//! *above* it pushes its own filter straight through into the same probe
+//! subtree, because `HashJoinExec` reports both sides of a `LeftAnti` as
+//! preserved for pushdown ("join key filters can be safely pushed down into
+//! the other side" — true for a plain anti join, false for a null-aware one).
+//! So the guard works at plan scope instead: when the plan contains a
+//! null-aware join at all, every rule runs with dynamic filter pushdown turned
+//! off, and no dynamic filter is created anywhere in that plan.
 //!
-//! The join keeps working without it: the filter is an optional pruning
-//! accelerator, and with it detached the shared expression is never refreshed
-//! from the build side and stays `true`. Only null-aware joins are touched, and
-//! a null-aware join always has a nullable join key (otherwise the planner
-//! would not have asked for null-aware semantics), so there is no case where
-//! this gives up pruning it could soundly have kept.
+//! Only static predicate pushdown is left alone, which is sound here — the
+//! probe side *is* the statically filtered subquery, so pruning it by its own
+//! predicate cannot change the answer. The cost is that a query containing a
+//! `NOT IN` gives up dynamic-filter pruning on its other joins too; that is the
+//! granularity the config exposes, and correctness wins.
 //!
-//! See <https://github.com/hotdata-dev/liquid-cache/issues/16>.
+//! Upstream guards this only when the *build* key is nullable, which misses the
+//! pruned-probe-NULL case entirely. See
+//! <https://github.com/hotdata-dev/liquid-cache/issues/16>.
 
 use std::sync::Arc;
 
 use datafusion::{
-    common::tree_node::{Transformed, TransformedResult, TreeNode},
+    common::tree_node::{TreeNode, TreeNodeRecursion},
     config::ConfigOptions,
     error::Result,
     physical_optimizer::PhysicalOptimizerRule,
     physical_plan::{ExecutionPlan, joins::HashJoinExec},
 };
 
-/// Physical optimizer rule that removes the build-side dynamic filter from
-/// null-aware anti joins, which cannot read their probe side correctly through
-/// it. See the module docs.
+/// Wraps a physical optimizer rule so it never gets to attach a dynamic filter
+/// to a plan that contains a null-aware anti join. See the module docs.
 ///
-/// Must run after the filter-pushdown rules that attach the dynamic filter,
-/// i.e. it belongs at the end of the physical optimizer list.
-#[derive(Debug, Default)]
-pub struct NullAwareJoinDynamicFilterGuard;
+/// Wrap every rule in the list — dynamic filters are created inside the
+/// filter-pushdown rules today, but nothing pins them there, and the wrapper is
+/// inert for a plan with no null-aware join.
+#[derive(Debug)]
+pub struct NoDynamicFiltersForNullAwareJoins {
+    inner: Arc<dyn PhysicalOptimizerRule + Send + Sync>,
+}
 
-impl NullAwareJoinDynamicFilterGuard {
-    /// Create the rule.
-    pub fn new() -> Self {
-        Self
+impl NoDynamicFiltersForNullAwareJoins {
+    /// Wrap `inner`.
+    pub fn new(inner: Arc<dyn PhysicalOptimizerRule + Send + Sync>) -> Self {
+        Self { inner }
+    }
+
+    /// Wrap every rule of DataFusion's default physical optimizer, ready to
+    /// hand to `SessionStateBuilder::with_physical_optimizer_rules`.
+    pub fn wrap_default_rules() -> Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> {
+        datafusion::physical_optimizer::optimizer::PhysicalOptimizer::new()
+            .rules
+            .into_iter()
+            .map(|rule| Arc::new(Self::new(rule)) as Arc<dyn PhysicalOptimizerRule + Send + Sync>)
+            .collect()
     }
 }
 
-impl PhysicalOptimizerRule for NullAwareJoinDynamicFilterGuard {
+/// Whether `plan` contains a hash join asking for null-aware semantics.
+fn has_null_aware_join(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    let mut found = false;
+    // `apply` only fails if the closure does, and this one cannot.
+    let _ = plan.apply(|node| {
+        Ok(match node.downcast_ref::<HashJoinExec>() {
+            Some(join) if join.null_aware => {
+                found = true;
+                TreeNodeRecursion::Stop
+            }
+            _ => TreeNodeRecursion::Continue,
+        })
+    });
+    found
+}
+
+impl PhysicalOptimizerRule for NoDynamicFiltersForNullAwareJoins {
     fn optimize(
         &self,
         plan: Arc<dyn ExecutionPlan>,
-        _config: &ConfigOptions,
+        config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        plan.transform_up(|node| {
-            let Some(join) = node.downcast_ref::<HashJoinExec>() else {
-                return Ok(Transformed::no(node));
-            };
-            if !join.null_aware || join.dynamic_filter_expr().is_none() {
-                return Ok(Transformed::no(node));
-            }
-            // `reset_state` clears the dynamic filter along with the build-side
-            // future and metrics, none of which carry anything yet at plan time.
-            Ok(Transformed::yes(join.builder().reset_state().build_exec()?))
-        })
-        .data()
+        if !has_null_aware_join(&plan) {
+            return self.inner.optimize(plan, config);
+        }
+        let mut config = config.clone();
+        let optimizer = &mut config.optimizer;
+        optimizer.enable_dynamic_filter_pushdown = false;
+        optimizer.enable_join_dynamic_filter_pushdown = false;
+        optimizer.enable_topk_dynamic_filter_pushdown = false;
+        optimizer.enable_aggregate_dynamic_filter_pushdown = false;
+        self.inner.optimize(plan, &config)
     }
 
     fn name(&self) -> &str {
-        "NullAwareJoinDynamicFilterGuard"
+        self.inner.name()
     }
 
     fn schema_check(&self) -> bool {
-        true
+        self.inner.schema_check()
     }
 }

--- a/src/datafusion/src/optimizers/null_aware_join.rs
+++ b/src/datafusion/src/optimizers/null_aware_join.rs
@@ -56,7 +56,9 @@
 //!   `a NOT IN (..) AND <anything on a>` is still wrong — wrong in vanilla
 //!   DataFusion over a `MemTable` with every dynamic filter off.
 //! - With `prefer_hash_join = false` the planner emits a `SortMergeJoinExec`
-//!   and drops `null_aware` outright, leaving no `HashJoinExec` to guard.
+//!   and drops `null_aware` outright. That leaves no `HashJoinExec` to guard,
+//!   so *both* guards go inert — the value guard keys off the same detection as
+//!   the join one, and is not independent of the hash-join path.
 //!
 //! Upstream guards the join's own filter only when the *build* key is nullable,
 //! which misses the pruned-probe-NULL case. See
@@ -257,5 +259,35 @@ impl PhysicalOptimizerRule for NullAwareValueFilterGuard {
 
     fn schema_check(&self) -> bool {
         self.inner.schema_check()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::config::ConfigOptions;
+
+    /// The guards cover the dynamic-filter publishers by name: the join filter
+    /// per-node, the TopK and aggregate filters plan-wide. A fifth publisher
+    /// behind a new `enable_*dynamic_filter*` flag would silently slip past
+    /// both, so pin the set rather than discover it from a wrong answer.
+    #[test]
+    fn dynamic_filter_flag_set_has_not_grown() {
+        let mut keys: Vec<String> = ConfigOptions::default()
+            .entries()
+            .into_iter()
+            .map(|entry| entry.key)
+            .filter(|key| key.contains("dynamic_filter"))
+            .collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            [
+                "datafusion.optimizer.enable_aggregate_dynamic_filter_pushdown",
+                "datafusion.optimizer.enable_dynamic_filter_pushdown",
+                "datafusion.optimizer.enable_join_dynamic_filter_pushdown",
+                "datafusion.optimizer.enable_topk_dynamic_filter_pushdown",
+            ],
+            "a new dynamic-filter flag means a new publisher to guard; see the module docs"
+        );
     }
 }


### PR DESCRIPTION
Fixes #16 for bare `NOT IN` — but not the wider class; see the issue comment for what remains open.

A null-aware `LeftAnti` join's answer depends on what its probe side *contains*, so any dynamic filter pushed into that probe scan prunes away the deciding NULL. The bug is upstream in DataFusion (vanilla parquet is equally wrong; only a `MemTable`, which takes no pushdown, answers correctly), so these two rules keep such filters off the probe side: the join filter per-node, so unrelated joins keep their pruning, and the TopK/aggregate filters plan-wide, since a `UNION ALL` sibling can tighten them before the probe is read.
