### PR TITLE
feat: build and test natively on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,28 @@ jobs:
                   files: codecov.json
                   fail_ci_if_error: true
 
+    macos:
+        # The only job that exercises the store's non-io_uring I/O backend and
+        # the portable (non-BMI2) selection path, both of which Linux never
+        # reaches. Excludes dev-tools, whose generated tailwind.css comes from
+        # the npm steps the Linux jobs run; benchmarks stay Linux-only because
+        # buffered I/O makes their numbers unrepresentative.
+        name: macOS
+        runs-on: macos-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  components: clippy
+            - uses: Swatinem/rust-cache@v2
+              with:
+                  shared-key: ci-${{ runner.os }}
+                  save-if: ${{ github.ref == 'refs/heads/main' }}
+            - name: Run clippy
+              run: cargo clippy --workspace --exclude dev-tools --all-targets --all-features -- -D warnings
+            - name: Run tests
+              run: cargo test --workspace --exclude dev-tools
+
     shuttle_test:
         name: Shuttle Test
         runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4312,7 +4312,6 @@ dependencies = [
  "liquid-cache-common",
  "liquid-cache-datafusion",
  "parquet",
- "t4",
  "tempfile",
  "tokio",
 ]
@@ -4341,7 +4340,6 @@ dependencies = [
  "prost",
  "serde",
  "sysinfo",
- "t4",
  "tempfile",
  "tokio",
  "tonic",

--- a/README.md
+++ b/README.md
@@ -93,9 +93,17 @@ tokio_test::block_on(async {
 
 ### LiquidCache uses DIRECT I/O
 
-By default, LiquidCache uses [DIRECT I/O](https://man7.org/linux/man-pages/man2/open.2.html#:~:text=O_DIRECT). This means that it bypasses the OS page cache, this avoids double-caching and bound memory usage. 
+On Linux, LiquidCache uses [DIRECT I/O](https://man7.org/linux/man-pages/man2/open.2.html#:~:text=O_DIRECT). This means that it bypasses the OS page cache, this avoids double-caching and bound memory usage. 
 
 This also means LiquidCache can *appear slower* than other caches when most data fits in OS page cache, which is common in dev environments but unrealistic in production.
+
+### Platform support
+
+LiquidCache builds, runs and passes its test suite on both Linux and macOS. DIRECT I/O is the exception: the underlying store implements it on Linux only, so every other target mounts with buffered I/O instead and logs a warning once at startup.
+
+That fallback keeps the cache correct — it writes, reads and evicts exactly as on Linux — but it costs the property the accounting depends on. Under DIRECT I/O a cached page exists once and the cache knows about it. Under buffered I/O the kernel holds a second copy that the cache does not count, so reported memory understates real residency, and the admission gate's budget is measured against an incomplete figure.
+
+So: **develop anywhere, measure on Linux.** Benchmark numbers from macOS are not comparable to production, and generally flatter LiquidCache rather than penalising it, since reads may be served from the page cache that DIRECT I/O deliberately avoids. Use a Linux machine or VM for any performance or capacity work.
 
 
 ### Use LiquidCache with DataFusion

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ That fallback keeps the cache correct — it writes, reads and evicts exactly as
 
 So: **develop anywhere, measure on Linux.** Benchmark numbers from macOS are not comparable to production, and generally flatter LiquidCache rather than penalising it, since reads may be served from the page cache that DIRECT I/O deliberately avoids. Use a Linux machine or VM for any performance or capacity work.
 
+Separately, and independent of the operating system: **compressed sizes differ slightly between arm64 and x86_64.** FSST picks its symbol table by draining a hash map into a priority queue, and its candidate ordering does not fully break ties, so equally-good symbols are chosen in hash-iteration order — which is not stable across architectures. The compressed output is valid and interchangeable either way, but a given column will not compress to exactly the same number of bytes on Graviton as on x86_64 (we measure ~0.4% on one test column). Compare compression ratios and capacity figures only within one architecture.
+
 
 ### Use LiquidCache with DataFusion
 

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -41,6 +41,11 @@ pprof = { version = "0.15.0", features = ["flamegraph"] }
 anyhow = "1.0"
 usdt = "0.6"
 regex = "1.12.4"
+
+# Hardware counters come from perf_event_open, a Linux-only syscall; the crate
+# does not compile anywhere else. See `PerfEventCollector` in
+# src/inprocess_runner.rs for the fallback.
+[target.'cfg(target_os = "linux")'.dependencies]
 perf-event2 = "0.7.4"
 
 [features]

--- a/benchmark/src/inprocess_runner.rs
+++ b/benchmark/src/inprocess_runner.rs
@@ -14,6 +14,7 @@ use liquid_cache::cache_policies::LiquidPolicy;
 use liquid_cache_datafusion::{LiquidCacheParquetRef, extract_execution_metrics};
 use liquid_cache_datafusion_local::LiquidCacheLocalBuilder;
 use log::{info, warn};
+#[cfg(target_os = "linux")]
 use perf_event::{
     Builder as PerfBuilder, Counter, Group,
     events::{Hardware, Software},
@@ -72,6 +73,13 @@ impl DiskIoGuard {
     }
 }
 
+/// Hardware and software counters for one query iteration.
+///
+/// `perf_event_open` is a Linux syscall, so off Linux the collector cannot be
+/// constructed at all — see the uninhabited stub below. Callers already treat a
+/// construction failure as "no counters this run", which is what we want:
+/// absent counters rather than fabricated zeroes.
+#[cfg(target_os = "linux")]
 struct PerfEventCollector {
     group: Group,
     cycles: Counter,
@@ -82,6 +90,7 @@ struct PerfEventCollector {
     page_faults: Counter,
 }
 
+#[cfg(target_os = "linux")]
 impl PerfEventCollector {
     fn new() -> io::Result<Self> {
         let mut group = Group::new()?;
@@ -156,6 +165,32 @@ impl PerfEventCollector {
                 .map(|entry| entry.value())
                 .unwrap_or(0),
         })
+    }
+}
+
+/// Stand-in for the collector on targets without `perf_event_open`.
+///
+/// Uninhabited, so the only reachable method is [`Self::new`], which always
+/// fails. `start` and `stop` are therefore statically unreachable and need no
+/// panic. Keeping the same shape as the Linux type means the call site is
+/// identical on every platform.
+#[cfg(not(target_os = "linux"))]
+enum PerfEventCollector {}
+
+#[cfg(not(target_os = "linux"))]
+impl PerfEventCollector {
+    fn new() -> io::Result<Self> {
+        Err(io::Error::other(
+            "hardware counters need perf_event_open, which only Linux provides",
+        ))
+    }
+
+    fn start(&mut self) -> io::Result<()> {
+        match *self {}
+    }
+
+    fn stop(self) -> io::Result<PerfEventStats> {
+        match self {}
     }
 }
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+	{ path = "t4::mount", reason = "use liquid_cache::store::mount so the store's I/O mode stays in one place" },
+	{ path = "t4::mount_with_options", reason = "use liquid_cache::store::mount so the store's I/O mode stays in one place" },
+]

--- a/flake.nix
+++ b/flake.nix
@@ -41,8 +41,6 @@
               llvmPackages.bintools
               lldb
               cargo-fuzz
-              bpftrace
-              perf
               nixd
               inferno
               cargo-flamegraph
@@ -55,6 +53,12 @@
                 extensions = [ "rust-src" "llvm-tools-preview" ];
                 targets = [ "x86_64-unknown-linux-gnu" "wasm32-unknown-unknown" ];
               }))
+            ]
+            # perf and bpftrace exist only on Linux in nixpkgs, and this flake
+            # is evaluated for every default system, macOS included.
+            ++ lib.optionals stdenv.isLinux [
+              bpftrace
+              perf
             ];
 
             shellHook = ''

--- a/src/core/src/cache/builders.rs
+++ b/src/core/src/cache/builders.rs
@@ -137,7 +137,7 @@ impl LiquidCacheBuilder {
             None => {
                 let cache_dir = tempfile::tempdir().unwrap().keep();
                 let store_path = cache_dir.join("liquid_cache.t4");
-                t4::mount(&store_path)
+                crate::store::mount(&store_path)
                     .await
                     .expect("failed to mount t4 store")
             }

--- a/src/core/src/cache/tests/squeezed.rs
+++ b/src/core/src/cache/tests/squeezed.rs
@@ -29,7 +29,7 @@ async fn read_squeezed_date_time() {
         .with_squeeze_policy(Box::new(TranscodeSqueezeEvict))
         .with_max_memory_bytes(array_size * 2)
         .with_store(
-            t4::mount(temp_dir.path().join("liquid_cache.t4"))
+            crate::store::mount(temp_dir.path().join("liquid_cache.t4"))
                 .await
                 .unwrap(),
         )
@@ -95,7 +95,7 @@ async fn read_squeezed_variant_path() {
         .with_squeeze_policy(Box::new(TranscodeSqueezeEvict))
         .with_max_memory_bytes(array_size * 3 / 2)
         .with_store(
-            t4::mount(temp_dir.path().join("liquid_cache.t4"))
+            crate::store::mount(temp_dir.path().join("liquid_cache.t4"))
                 .await
                 .unwrap(),
         )
@@ -158,7 +158,7 @@ async fn read_squeezed_int64_array() {
         .with_squeeze_policy(Box::new(TranscodeSqueezeEvict))
         .with_max_memory_bytes(array_size * 2)
         .with_store(
-            t4::mount(temp_dir.path().join("liquid_cache.t4"))
+            crate::store::mount(temp_dir.path().join("liquid_cache.t4"))
                 .await
                 .unwrap(),
         )

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod cache;
 pub mod liquid_array;
+pub mod store;
 mod sync;
 pub mod utils;
 

--- a/src/core/src/store.rs
+++ b/src/core/src/store.rs
@@ -14,7 +14,6 @@
 //! That makes non-Linux fine for development and wrong for measurement.
 
 use std::path::Path;
-use std::sync::Once;
 
 /// Mount the on-disk store for a LiquidCache instance at `path`, which is the
 /// full path to the store file.
@@ -44,7 +43,7 @@ pub async fn mount(path: impl AsRef<Path>) -> t4::Result<t4::Store> {
 
 #[cfg(not(target_os = "linux"))]
 fn warn_buffered_once() {
-    static WARNED: Once = Once::new();
+    static WARNED: std::sync::Once = std::sync::Once::new();
     WARNED.call_once(|| {
         log::warn!(
             "mounting the liquid cache store with buffered I/O: t4 implements DIRECT I/O on Linux \

--- a/src/core/src/store.rs
+++ b/src/core/src/store.rs
@@ -1,0 +1,93 @@
+//! Mounting the on-disk store that backs the cache's disk tier.
+//!
+//! LiquidCache wants DIRECT I/O. Bypassing the OS page cache is what makes the
+//! cache's own byte accounting the whole truth: one copy of a cached page
+//! exists, and the cache knows about it. The admission gate
+//! ([`crate::cache`] budgets, and `liquid-cache-datafusion`'s footprint gate)
+//! is built on that premise.
+//!
+//! [`t4`] only implements DIRECT I/O on Linux — every other target refuses the
+//! option outright rather than silently ignoring it. So off Linux we mount
+//! buffered and say so. The cache stays correct: it writes, reads and evicts
+//! exactly as before. What it loses is the accounting guarantee, because the
+//! kernel now keeps a second copy of every page that the cache does not count.
+//! That makes non-Linux fine for development and wrong for measurement.
+
+use std::path::Path;
+use std::sync::Once;
+
+/// Whether this target mounts the on-disk store with DIRECT I/O.
+///
+/// `false` means the OS page cache holds an uncounted second copy of cached
+/// pages, so byte accounting understates real residency. Benchmark and
+/// capacity-planning numbers are only meaningful when this is `true`.
+pub const DIRECT_IO: bool = cfg!(target_os = "linux");
+
+/// Mount the on-disk store for a LiquidCache instance at `path`.
+///
+/// Prefer this over calling [`t4::mount`] directly: it is the one place that
+/// decides the store's I/O mode, so the choice cannot drift between the cache
+/// builders, the server, benches and tests.
+#[cfg(target_os = "linux")]
+pub async fn mount(path: impl AsRef<Path>) -> t4::Result<t4::Store> {
+    t4::mount(path).await
+}
+
+/// Mount the on-disk store for a LiquidCache instance at `path`.
+///
+/// See the [module docs](self) for what buffered I/O costs off Linux.
+#[cfg(not(target_os = "linux"))]
+pub async fn mount(path: impl AsRef<Path>) -> t4::Result<t4::Store> {
+    static WARNED: Once = Once::new();
+    WARNED.call_once(|| {
+        log::warn!(
+            "mounting the liquid cache store with buffered I/O: t4 supports DIRECT I/O on Linux \
+             only. The cache is functional, but the OS page cache holds a second copy of cached \
+             pages that the cache does not count, so memory accounting understates residency. \
+             Measure performance on Linux."
+        );
+    });
+
+    // `dsync` stays at t4's default: O_DSYNC is honoured off Linux, so keeping
+    // it preserves the write-durability semantics Linux gets.
+    t4::mount_with_options(
+        path,
+        t4::MountOptions {
+            direct_io: false,
+            ..Default::default()
+        },
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The store must mount, round-trip a value and survive a remount on every
+    /// platform. On Linux this covers t4's io_uring backend; elsewhere it is the
+    /// only coverage the generic thread-pool backend gets.
+    #[tokio::test]
+    async fn mount_round_trips_on_this_platform() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("liquid_cache.t4");
+
+        let store = mount(&path).await.expect("mount must succeed");
+        store.put(b"key".to_vec(), b"hello".to_vec()).await.unwrap();
+        assert_eq!(store.get(b"key").await.unwrap(), b"hello");
+        store.sync().await.unwrap();
+        drop(store);
+
+        let store = mount(&path).await.expect("remount must succeed");
+        assert_eq!(
+            store.get(b"key").await.unwrap(),
+            b"hello",
+            "a remounted store must replay what was written"
+        );
+    }
+
+    #[test]
+    fn direct_io_tracks_the_target() {
+        assert_eq!(DIRECT_IO, cfg!(target_os = "linux"));
+    }
+}

--- a/src/core/src/store.rs
+++ b/src/core/src/store.rs
@@ -25,6 +25,10 @@ use std::path::Path;
 /// On Linux this is exactly [`t4::mount`] — `direct_io` and `dsync` both come
 /// out `true`, matching [`t4::MountOptions::default`]. See the
 /// [module docs](self) for what the buffered fallback costs elsewhere.
+// The one place allowed to mount through `t4` directly — `clippy.toml` sends
+// every other call site here, so this is where the `disallowed_methods` rule has
+// to stop.
+#[allow(clippy::disallowed_methods)]
 pub async fn mount(path: impl AsRef<Path>) -> t4::Result<t4::Store> {
     #[cfg(not(target_os = "linux"))]
     warn_buffered_once();

--- a/src/core/src/store.rs
+++ b/src/core/src/store.rs
@@ -16,48 +16,44 @@
 use std::path::Path;
 use std::sync::Once;
 
-/// Whether this target mounts the on-disk store with DIRECT I/O.
-///
-/// `false` means the OS page cache holds an uncounted second copy of cached
-/// pages, so byte accounting understates real residency. Benchmark and
-/// capacity-planning numbers are only meaningful when this is `true`.
-pub const DIRECT_IO: bool = cfg!(target_os = "linux");
-
-/// Mount the on-disk store for a LiquidCache instance at `path`.
+/// Mount the on-disk store for a LiquidCache instance at `path`, which is the
+/// full path to the store file.
 ///
 /// Prefer this over calling [`t4::mount`] directly: it is the one place that
 /// decides the store's I/O mode, so the choice cannot drift between the cache
 /// builders, the server, benches and tests.
-#[cfg(target_os = "linux")]
-pub async fn mount(path: impl AsRef<Path>) -> t4::Result<t4::Store> {
-    t4::mount(path).await
-}
-
-/// Mount the on-disk store for a LiquidCache instance at `path`.
 ///
-/// See the [module docs](self) for what buffered I/O costs off Linux.
-#[cfg(not(target_os = "linux"))]
+/// On Linux this is exactly [`t4::mount`] — `direct_io` and `dsync` both come
+/// out `true`, matching [`t4::MountOptions::default`]. See the
+/// [module docs](self) for what the buffered fallback costs elsewhere.
 pub async fn mount(path: impl AsRef<Path>) -> t4::Result<t4::Store> {
-    static WARNED: Once = Once::new();
-    WARNED.call_once(|| {
-        log::warn!(
-            "mounting the liquid cache store with buffered I/O: t4 supports DIRECT I/O on Linux \
-             only. The cache is functional, but the OS page cache holds a second copy of cached \
-             pages that the cache does not count, so memory accounting understates residency. \
-             Measure performance on Linux."
-        );
-    });
+    #[cfg(not(target_os = "linux"))]
+    warn_buffered_once();
 
-    // `dsync` stays at t4's default: O_DSYNC is honoured off Linux, so keeping
-    // it preserves the write-durability semantics Linux gets.
+    // `dsync` stays at t4's default: O_DSYNC is honoured off Linux too, so the
+    // fallback keeps the write-durability semantics Linux gets.
     t4::mount_with_options(
         path,
         t4::MountOptions {
-            direct_io: false,
+            direct_io: cfg!(target_os = "linux"),
             ..Default::default()
         },
     )
     .await
+}
+
+#[cfg(not(target_os = "linux"))]
+fn warn_buffered_once() {
+    static WARNED: Once = Once::new();
+    WARNED.call_once(|| {
+        log::warn!(
+            "mounting the liquid cache store with buffered I/O: t4 implements DIRECT I/O on Linux \
+             only. The cache is fully functional, but memory accounting now excludes the kernel \
+             page-cache copy of every cached page, so reported usage understates real residency \
+             and the admission gate's budget is measured against an incomplete figure. Measure \
+             performance on Linux."
+        );
+    });
 }
 
 #[cfg(test)]
@@ -84,10 +80,5 @@ mod tests {
             b"hello",
             "a remounted store must replay what was written"
         );
-    }
-
-    #[test]
-    fn direct_io_tracks_the_target() {
-        assert_eq!(DIRECT_IO, cfg!(target_os = "linux"));
     }
 }

--- a/src/core/study/cache_storage.rs
+++ b/src/core/study/cache_storage.rs
@@ -46,7 +46,8 @@ fn main() {
         .clone()
         .unwrap_or_else(|| tempfile::tempdir().unwrap().keep());
     let store_path = cache_dir.join("liquid_cache.t4");
-    let store = tokio_test::block_on(t4::mount(&store_path)).expect("failed to mount t4 store");
+    let store = tokio_test::block_on(liquid_cache::store::mount(&store_path))
+        .expect("failed to mount t4 store");
     let storage = tokio_test::block_on(async {
         LiquidCacheBuilder::new()
             .with_max_memory_bytes(500 * 1024 * 1024)

--- a/src/datafusion-local/Cargo.toml
+++ b/src/datafusion-local/Cargo.toml
@@ -17,7 +17,6 @@ arrow = { workspace = true }
 arrow-schema = { workspace = true }
 tokio = { workspace = true }
 fastrace = { workspace = true }
-t4 = { workspace = true }
 
 
 [dev-dependencies]

--- a/src/datafusion-local/src/lib.rs
+++ b/src/datafusion-local/src/lib.rs
@@ -185,19 +185,9 @@ impl LiquidCacheLocalBuilder {
         config.options_mut().execution.parquet.skip_metadata = false;
         config.options_mut().execution.batch_size = self.batch_size;
 
-        // t4's default MountOptions enable direct_io, which only Linux
-        // supports; everywhere else the mount fails outright. Keep direct_io
-        // on Linux (production) and fall back to buffered I/O elsewhere so
-        // local mode — and its tests — run on macOS dev machines.
-        let store = t4::mount_with_options(
-            self.cache_dir.join("liquid_cache.t4"),
-            t4::MountOptions {
-                direct_io: cfg!(target_os = "linux"),
-                ..Default::default()
-            },
-        )
-        .await
-        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+        let store = liquid_cache::store::mount(self.cache_dir.join("liquid_cache.t4"))
+            .await
+            .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
         #[cfg(not(test))]
         let cache = LiquidCacheParquet::new(
             self.batch_size,

--- a/src/datafusion-local/src/tests/mod.rs
+++ b/src/datafusion-local/src/tests/mod.rs
@@ -335,25 +335,37 @@ async fn test_single_column_filter_projection() {
     test_runner(sql, &reference, cache_dir.path()).await;
 }
 
-/// Runs on Linux only, because the snapshot pins `usage.memory_bytes` exactly
-/// and aarch64-darwin reports 935 bytes less at every one of the three
-/// measurement points (1000915 -> 999980, 1036304 -> 1035369), reproducibly.
+/// Runs on x86_64 only, because the snapshot pins `usage.memory_bytes` exactly
+/// and aarch64 reports 935 bytes less at every one of the three measurement
+/// points (1000915 -> 999980, 1036304 -> 1035369), reproducibly.
 ///
-/// Why is not yet known. Ruled out so far: `target_partitions` (pinned to 4
-/// below, so it is not the host's CPU count), the temp directory path, the
-/// liquid encoding itself (`usage.disk_bytes` is identical at 35000, and the
-/// entry mix — 5 memory.arrow, 1 memory.liquid, 2 disk.liquid — matches), and
-/// buffer alignment (the string-view data buffers this file produces have
-/// `capacity == len`, so the accounting is exact rather than rounded, which is
-/// what makes an odd 935-byte delta possible in the first place).
+/// The split is by architecture, not by OS. Measured:
 ///
-/// Diagnosing it needs a Linux and a macOS run side by side. Until then this
-/// stays gated rather than redacted, so the Linux assertion keeps its full
-/// strength and the `cargo insta` workflow keeps working. To see the diff on
-/// macOS: `cargo test -p liquid-cache-datafusion-local -- --ignored`.
+/// | target              | usage.memory_bytes |
+/// |---------------------|--------------------|
+/// | x86_64-linux        | 1000915 (recorded) |
+/// | aarch64-linux       | 999980             |
+/// | aarch64-darwin      | 999980             |
+///
+/// aarch64-linux and aarch64-darwin agree exactly, so the OS is not the
+/// variable — gating on `target_os` would still fail on Graviton or on any ARM
+/// Linux runner.
+///
+/// Why the architectures differ is still unknown. Ruled out: `target_partitions`
+/// (pinned to 4 below, so not the host CPU count), the temp directory path, the
+/// serialized liquid encoding (`usage.disk_bytes` is identical at 35000 and the
+/// entry mix — 5 memory.arrow, 1 memory.liquid, 2 disk.liquid — matches, so only
+/// the in-memory footprint moves), and buffer rounding (the string-view data
+/// buffers this file produces have `capacity == len`, so the accounting is exact,
+/// which is what admits an odd 935-byte delta at all). `fastlanes` bit-packing is
+/// the obvious next place to look.
+///
+/// Gated rather than redacted so the x86_64 assertion keeps full strength and the
+/// `cargo insta` workflow keeps working. To see the diff elsewhere:
+/// `cargo test -p liquid-cache-datafusion-local -- --ignored`.
 #[cfg_attr(
-    not(target_os = "linux"),
-    ignore = "snapshot pins exact memory_bytes; aarch64-darwin differs by 935 bytes"
+    not(target_arch = "x86_64"),
+    ignore = "snapshot pins exact memory_bytes; aarch64 differs by 935 bytes"
 )]
 #[tokio::test]
 async fn test_provide_schema2() {

--- a/src/datafusion-local/src/tests/mod.rs
+++ b/src/datafusion-local/src/tests/mod.rs
@@ -465,27 +465,39 @@ async fn test_provide_schema2() {
     // Off x86_64 the byte-exact snapshot cannot match, because FSST picks a
     // different symbol table (see above). Bound the figures instead of skipping
     // the test: arm64 is a production target, so it still deserves a tripwire on
-    // a gross accounting regression, and everything else this test covers — the
-    // plans, the cache hits, the tier split, the `Utf8`-declared schema over a
-    // `string_view` file — is architecture-independent and worth running.
+    // a gross accounting regression. The plan text is only checked byte-for-byte
+    // on x86_64, but what this test covers besides it — the DataFusion-vs-liquid
+    // column equality, the cache hits, the tier split, the `Utf8`-declared schema
+    // over a `string_view` file — is architecture-independent and worth running.
     #[cfg(not(target_arch = "x86_64"))]
-    assert_memory_bytes_within_1pct(&snapshot, &[1000915, 1000915, 1036304]);
+    assert_memory_bytes_within_1pct(
+        &snapshot,
+        include_str!("snapshots/liquid_cache_datafusion_local__tests__provide_schema2.snap"),
+    );
 }
 
-/// Checks each `usage.memory_bytes` line in `snapshot` against the value recorded
-/// on x86_64, allowing 1%.
+/// Checks each `usage.memory_bytes` line in `snapshot` against the figure the
+/// committed x86_64 snapshot records for the same query, allowing 1%.
+///
+/// `recorded` is the `.snap` file itself rather than a hand-copied array, so
+/// regenerating the snapshot on x86_64 with `cargo insta accept` cannot leave
+/// this assertion silently checking stale numbers.
 ///
 /// The known architecture difference is ~0.1% (935 bytes in ~1 MiB), so 1% has an
 /// order of magnitude of headroom while still catching the kind of regression that
 /// matters — a buffer counted twice, or a tier accounted at the wrong size.
 #[cfg(not(target_arch = "x86_64"))]
-fn assert_memory_bytes_within_1pct(snapshot: &str, expected: &[u64]) {
-    let actual: Vec<u64> = snapshot
-        .lines()
-        .filter_map(|line| line.strip_prefix("usage.memory_bytes: "))
-        .map(|value| value.trim().parse().expect("memory_bytes must be a number"))
-        .collect();
+fn assert_memory_bytes_within_1pct(snapshot: &str, recorded: &str) {
+    let actual = memory_bytes(snapshot);
+    let expected = memory_bytes(recorded);
 
+    // Both sides are parsed with the same predicate, so a changed prefix would
+    // empty both and make the length check below pass on nothing.
+    assert!(
+        !expected.is_empty(),
+        "found no `usage.memory_bytes` readings in the committed snapshot; the \
+         stats format has changed and this assertion is no longer reading anything"
+    );
     assert_eq!(
         actual.len(),
         expected.len(),
@@ -494,7 +506,7 @@ fn assert_memory_bytes_within_1pct(snapshot: &str, expected: &[u64]) {
         actual.len()
     );
 
-    for (idx, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+    for (idx, (&actual, &expected)) in actual.iter().zip(&expected).enumerate() {
         let drift = actual.abs_diff(expected);
         assert!(
             drift * 100 <= expected,
@@ -503,6 +515,19 @@ fn assert_memory_bytes_within_1pct(snapshot: &str, expected: &[u64]) {
              be ~0.1%, so this is a real accounting change"
         );
     }
+}
+
+/// Pulls every `usage.memory_bytes` figure out of a stats snapshot, in order.
+///
+/// Works on both the live snapshot and a committed `.snap` file: insta writes the
+/// snapshot body unindented after its YAML header, so the same prefix matches.
+#[cfg(not(target_arch = "x86_64"))]
+fn memory_bytes(snapshot: &str) -> Vec<u64> {
+    snapshot
+        .lines()
+        .filter_map(|line| line.strip_prefix("usage.memory_bytes: "))
+        .map(|value| value.trim().parse().expect("memory_bytes must be a number"))
+        .collect()
 }
 
 #[tokio::test]

--- a/src/datafusion-local/src/tests/mod.rs
+++ b/src/datafusion-local/src/tests/mod.rs
@@ -375,13 +375,9 @@ async fn test_single_column_filter_projection() {
 /// at 35000 is not evidence against that; the two disk-resident entries are
 /// different, much smaller columns than the one that moves.
 ///
-/// Gated rather than redacted so the x86_64 assertion keeps full strength and the
-/// `cargo insta` workflow keeps working. To see the diff elsewhere:
-/// `cargo test -p liquid-cache-datafusion-local -- --ignored`.
-#[cfg_attr(
-    not(target_arch = "x86_64"),
-    ignore = "snapshot pins exact memory_bytes; aarch64 differs by 935 bytes"
-)]
+/// The byte-exact snapshot therefore runs on x86_64 only, keeping its full
+/// strength and the `cargo insta` workflow there. Everywhere else the test still
+/// runs and bounds the same figures to within 1% — see the bottom of this test.
 #[tokio::test]
 async fn test_provide_schema2() {
     use std::fmt::Write as _;
@@ -463,7 +459,50 @@ async fn test_provide_schema2() {
         }
     }
 
+    #[cfg(target_arch = "x86_64")]
     insta::assert_snapshot!(snapshot);
+
+    // Off x86_64 the byte-exact snapshot cannot match, because FSST picks a
+    // different symbol table (see above). Bound the figures instead of skipping
+    // the test: arm64 is a production target, so it still deserves a tripwire on
+    // a gross accounting regression, and everything else this test covers — the
+    // plans, the cache hits, the tier split, the `Utf8`-declared schema over a
+    // `string_view` file — is architecture-independent and worth running.
+    #[cfg(not(target_arch = "x86_64"))]
+    assert_memory_bytes_within_1pct(&snapshot, &[1000915, 1000915, 1036304]);
+}
+
+/// Checks each `usage.memory_bytes` line in `snapshot` against the value recorded
+/// on x86_64, allowing 1%.
+///
+/// The known architecture difference is ~0.1% (935 bytes in ~1 MiB), so 1% has an
+/// order of magnitude of headroom while still catching the kind of regression that
+/// matters — a buffer counted twice, or a tier accounted at the wrong size.
+#[cfg(not(target_arch = "x86_64"))]
+fn assert_memory_bytes_within_1pct(snapshot: &str, expected: &[u64]) {
+    let actual: Vec<u64> = snapshot
+        .lines()
+        .filter_map(|line| line.strip_prefix("usage.memory_bytes: "))
+        .map(|value| value.trim().parse().expect("memory_bytes must be a number"))
+        .collect();
+
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "expected {} memory_bytes readings, found {}: {actual:?}",
+        expected.len(),
+        actual.len()
+    );
+
+    for (idx, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        let drift = actual.abs_diff(expected);
+        assert!(
+            drift * 100 <= expected,
+            "query[{idx}]: memory_bytes {actual} is more than 1% from the x86_64 \
+             figure {expected} (off by {drift}); the architecture difference should \
+             be ~0.1%, so this is a real accounting change"
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/datafusion-local/src/tests/mod.rs
+++ b/src/datafusion-local/src/tests/mod.rs
@@ -351,14 +351,29 @@ async fn test_single_column_filter_projection() {
 /// variable — gating on `target_os` would still fail on Graviton or on any ARM
 /// Linux runner.
 ///
-/// Why the architectures differ is still unknown. Ruled out: `target_partitions`
-/// (pinned to 4 below, so not the host CPU count), the temp directory path, the
-/// serialized liquid encoding (`usage.disk_bytes` is identical at 35000 and the
-/// entry mix — 5 memory.arrow, 1 memory.liquid, 2 disk.liquid — matches, so only
-/// the in-memory footprint moves), and buffer rounding (the string-view data
-/// buffers this file produces have `capacity == len`, so the accounting is exact,
-/// which is what admits an odd 935-byte delta at all). `fastlanes` bit-packing is
-/// the obvious next place to look.
+/// The whole delta is the FSST-compressed payload — `RawFsstBuffer::values.len()`.
+/// Componentwise, everything else is byte-identical across the two architectures
+/// (the arrow entries, the fastlanes bit-packed dictionary keys at 17504, the
+/// prefix keys, the compact offsets, the struct sizes, and the 537585 bytes of
+/// uncompressed FSST input). Only the compressed output moves: 254655 on aarch64
+/// against 255590 on x86_64.
+///
+/// Cause: `fsst-rs` 0.5.11 drains a hash map of symbol candidates into a
+/// `BinaryHeap` (`builder.rs:796`), and `Candidate`'s ordering key is just
+/// `(gain, symbol.len())` (`builder.rs:835-837`) — the symbol bytes are excluded.
+/// Two distinct symbols with equal gain and equal length therefore compare
+/// `Equal`, so which one wins is decided by heap insertion order, i.e. hash-map
+/// iteration order, which is not stable across architectures (hashbrown selects
+/// an SSE2, NEON or generic probe implementation per target). Different
+/// tie-break, different 255-symbol table, different compressed length. The real
+/// fix belongs upstream: make `Candidate`'s ordering total by including the
+/// symbol bytes as a final tie-breaker.
+///
+/// Note this means liquid-encoded bytes are NOT identical across architectures —
+/// `to_bytes` writes `values` verbatim — so compression ratios and capacity
+/// figures do not transfer between arm64 and x86_64. `usage.disk_bytes` staying
+/// at 35000 is not evidence against that; the two disk-resident entries are
+/// different, much smaller columns than the one that moves.
 ///
 /// Gated rather than redacted so the x86_64 assertion keeps full strength and the
 /// `cargo insta` workflow keeps working. To see the diff elsewhere:

--- a/src/datafusion-local/src/tests/mod.rs
+++ b/src/datafusion-local/src/tests/mod.rs
@@ -335,6 +335,26 @@ async fn test_single_column_filter_projection() {
     test_runner(sql, &reference, cache_dir.path()).await;
 }
 
+/// Runs on Linux only, because the snapshot pins `usage.memory_bytes` exactly
+/// and aarch64-darwin reports 935 bytes less at every one of the three
+/// measurement points (1000915 -> 999980, 1036304 -> 1035369), reproducibly.
+///
+/// Why is not yet known. Ruled out so far: `target_partitions` (pinned to 4
+/// below, so it is not the host's CPU count), the temp directory path, the
+/// liquid encoding itself (`usage.disk_bytes` is identical at 35000, and the
+/// entry mix — 5 memory.arrow, 1 memory.liquid, 2 disk.liquid — matches), and
+/// buffer alignment (the string-view data buffers this file produces have
+/// `capacity == len`, so the accounting is exact rather than rounded, which is
+/// what makes an odd 935-byte delta possible in the first place).
+///
+/// Diagnosing it needs a Linux and a macOS run side by side. Until then this
+/// stays gated rather than redacted, so the Linux assertion keeps its full
+/// strength and the `cargo insta` workflow keeps working. To see the diff on
+/// macOS: `cargo test -p liquid-cache-datafusion-local -- --ignored`.
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "snapshot pins exact memory_bytes; aarch64-darwin differs by 935 bytes"
+)]
 #[tokio::test]
 async fn test_provide_schema2() {
     use std::fmt::Write as _;

--- a/src/datafusion-local/src/tests/page_index.rs
+++ b/src/datafusion-local/src/tests/page_index.rs
@@ -136,8 +136,8 @@ fn fixture_is_rejected_by_required_policy() {
 /// Scanning such a file through LiquidCache must succeed. The predicate matters:
 /// it is what builds the page-pruning predicate that consults the index.
 ///
-/// The local builder mounts t4 with buffered I/O off Linux, so unlike the
-/// direct-`t4::mount` suites this runs on every dev machine, not just CI.
+/// The store is mounted through `liquid_cache::store::mount`, which uses
+/// buffered I/O off Linux, so this runs on every dev machine, not just CI.
 #[tokio::test]
 async fn scans_file_without_offset_index() {
     let dir = TempDir::new().unwrap();

--- a/src/datafusion-server/Cargo.toml
+++ b/src/datafusion-server/Cargo.toml
@@ -38,7 +38,6 @@ fastrace = { workspace = true }
 pprof = { version = "0.15.0", features = ["flamegraph"] }
 anyhow = "1.0"
 liquid-cache = { workspace = true }
-t4 = { workspace = true }
 hdrhistogram = "7.5.4"
 
 [dev-dependencies]

--- a/src/datafusion-server/src/service.rs
+++ b/src/datafusion-server/src/service.rs
@@ -58,7 +58,7 @@ impl LiquidCacheServiceInner {
         let liquid_cache_dir = disk_cache_dir.join("liquid");
         std::fs::create_dir_all(&liquid_cache_dir).expect("Failed to create liquid cache dir");
 
-        let store = t4::mount(liquid_cache_dir.join("liquid_cache.t4"))
+        let store = liquid_cache::store::mount(liquid_cache_dir.join("liquid_cache.t4"))
             .await
             .expect("Failed to mount t4 store");
         let liquid_cache = Arc::new(

--- a/src/datafusion/bench/filter_pushdown.rs
+++ b/src/datafusion/bench/filter_pushdown.rs
@@ -40,7 +40,8 @@ fn create_boolean_filter(array_size: usize, selectivity: f64) -> BooleanBuffer {
 fn setup_cache() -> (Arc<CachedColumn>, tempfile::TempDir) {
     let tmp_dir = tempfile::tempdir().unwrap();
     let store_path = tmp_dir.path().join("liquid_cache.t4");
-    let store = tokio_test::block_on(t4::mount(&store_path)).expect("failed to mount t4 store");
+    let store = tokio_test::block_on(liquid_cache::store::mount(&store_path))
+        .expect("failed to mount t4 store");
     let cache = tokio_test::block_on(LiquidCacheParquet::new(
         BATCH_SIZE,
         1024 * 1024 * 1024, // max_memory_bytes (1GB)

--- a/src/datafusion/clippy.toml
+++ b/src/datafusion/clippy.toml
@@ -1,4 +1,9 @@
-disallowed-methods = []
+# Kept in sync with the workspace-root `clippy.toml`: clippy reads exactly one
+# config file per crate, so a crate with its own gets no inheritance.
+disallowed-methods = [
+	{ path = "t4::mount", reason = "use liquid_cache::store::mount so the store's I/O mode stays in one place" },
+	{ path = "t4::mount_with_options", reason = "use liquid_cache::store::mount so the store's I/O mode stays in one place" },
+]
 
 disallowed-types = [
 	{ path = "dashmap::DashMap", reason = "DashMap can easily lead to deadlocks, use RwLock<HashMap> with shuttle tests instead" },

--- a/src/datafusion/src/lib.rs
+++ b/src/datafusion/src/lib.rs
@@ -11,24 +11,12 @@ pub(crate) mod utils;
 pub(crate) mod test_utils {
     //! Shared helpers for this crate's tests.
 
-    /// Mount a t4 store for a test.
-    ///
-    /// t4's default [`t4::MountOptions`] enable `direct_io`, which only Linux
-    /// supports; everywhere else the mount fails outright with
-    /// `direct_io not supported on target_os`. Keep it on Linux (production, CI)
-    /// and fall back to buffered I/O elsewhere, matching what
-    /// `LiquidCacheLocalBuilder` does, so these tests run on macOS dev machines
-    /// too.
+    /// Mount a t4 store for a test, using the same I/O mode the cache uses in
+    /// production on this platform.
     pub(crate) async fn mount_test_store(dir: &std::path::Path) -> t4::Store {
-        t4::mount_with_options(
-            dir.join("liquid_cache.t4"),
-            t4::MountOptions {
-                direct_io: cfg!(target_os = "linux"),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect("mount t4 test store")
+        liquid_cache::store::mount(dir.join("liquid_cache.t4"))
+            .await
+            .expect("mount t4 test store")
     }
 }
 

--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -47,6 +47,12 @@ use crate::{LiquidCacheParquetRef, LiquidParquetSource, cache::ColumnSqueezeHint
 /// The estimate multiplies the raw required parquet bytes by `expansion`
 /// (parquet -> liquid in-memory blow-up) and `safety` (extra margin); both are
 /// `>= 1.0` so the estimate is conservative (over-counts).
+///
+/// The budget assumes the bytes the cache counts are the bytes actually
+/// resident, which holds only under DIRECT I/O. Off Linux the store falls back
+/// to buffered I/O (see [`liquid_cache::store`]) and the kernel keeps an
+/// uncounted second copy, so real residency exceeds the figure this gate is
+/// measured against. Tune these knobs on Linux.
 #[derive(Debug, Clone, Copy)]
 pub struct AdmissionGate {
     /// Parquet-bytes -> liquid-in-memory-bytes multiplier (>= 1.0). Inflates the

--- a/src/datafusion/src/utils.rs
+++ b/src/datafusion/src/utils.rs
@@ -320,6 +320,14 @@ mod tests {
     /// aarch64, and on any x86_64 CPU without BMI2, since the fast path is
     /// chosen at runtime — would have no test of its own at all.
     ///
+    /// Which implementation these tests reach therefore depends on the host,
+    /// because they go through the public dispatcher: BMI2 on an x86_64 CPU that
+    /// has it, the portable path everywhere else. That is deliberate. Between the
+    /// two CI targets each implementation gets checked against this reference,
+    /// and on x86_64 it also pins BMI2 to an oracle it does not share code with —
+    /// the pre-existing differential tests only ever compared the two
+    /// implementations to each other, which a mistake common to both would pass.
+    ///
     /// Both operands are assumed to start at bit 0, which is all the sole
     /// caller ever passes. That limit is real and untested on purpose: the
     /// fallback mishandles a bit-offset (sliced) `left`, because it seeds the

--- a/src/datafusion/src/utils.rs
+++ b/src/datafusion/src/utils.rs
@@ -312,6 +312,113 @@ pub fn extract_execution_metrics(
 mod tests {
     use super::*;
 
+    /// Spells out `boolean_buffer_and_then`'s contract directly: walk `left`,
+    /// and each time it is set, take the next bit of `right`.
+    ///
+    /// The BMI2 differential tests below can only run on x86_64, so without an
+    /// independent reference the portable path — which is what executes on
+    /// aarch64, and on any x86_64 CPU without BMI2, since the fast path is
+    /// chosen at runtime — would have no test of its own at all.
+    ///
+    /// Both operands are assumed to start at bit 0. Neither implementation
+    /// handles a bit-offset (sliced) `left`, and they disagree with each other
+    /// on a bit-offset `right`; the sole caller only ever passes offset-0
+    /// buffers. Offset handling is tracked separately and is deliberately not
+    /// exercised here.
+    fn reference_and_then(left: &BooleanBuffer, right: &BooleanBuffer) -> Vec<bool> {
+        debug_assert_eq!(left.offset(), 0);
+        debug_assert_eq!(right.offset(), 0);
+        let mut right_bits = right.iter();
+        (0..left.len())
+            .map(|i| {
+                left.value(i)
+                    && right_bits
+                        .next()
+                        .expect("right must have one bit per set bit of left")
+            })
+            .collect()
+    }
+
+    fn buffer_of(bits: &[bool]) -> BooleanBuffer {
+        let mut builder = BooleanBufferBuilder::new(bits.len());
+        for &bit in bits {
+            builder.append(bit);
+        }
+        builder.finish()
+    }
+
+    fn assert_matches_reference(left: &[bool], right: &[bool]) {
+        let (left, right) = (buffer_of(left), buffer_of(right));
+        assert_eq!(
+            left.count_set_bits(),
+            right.len(),
+            "malformed case: right must have one bit per set bit of left"
+        );
+
+        let expected = reference_and_then(&left, &right);
+        let actual = boolean_buffer_and_then(&left, &right);
+
+        assert_eq!(actual.len(), left.len());
+        let actual: Vec<bool> = (0..actual.len()).map(|i| actual.value(i)).collect();
+        assert_eq!(actual, expected);
+    }
+
+    /// Lengths chosen around the 64-bit word boundary the BMI2 path iterates on:
+    /// below one word, exactly one word, and a word plus a partial tail.
+    #[test]
+    fn and_then_matches_reference_across_shapes() {
+        // Empty.
+        assert_matches_reference(&[], &[]);
+
+        // Nothing selected: `right` is empty, output is all false.
+        assert_matches_reference(&[false; 8], &[]);
+        assert_matches_reference(&[false; 100], &[]);
+
+        // Everything selected, so `left.len() == right.len()` — this is the
+        // early-return path that clones `right` outright.
+        assert_matches_reference(
+            &[true; 8],
+            &[true, false, true, false, true, false, true, true],
+        );
+
+        for len in [1, 7, 8, 9, 63, 64, 65, 127, 128, 129, 200] {
+            // Every third bit set, alternating bits in `right`.
+            let left: Vec<bool> = (0..len).map(|i| i % 3 == 0).collect();
+            let right: Vec<bool> = (0..left.iter().filter(|b| **b).count())
+                .map(|i| i % 2 == 0)
+                .collect();
+            assert_matches_reference(&left, &right);
+
+            // All set, and all of `right` set: output must equal `left`.
+            let all: Vec<bool> = vec![true; len];
+            assert_matches_reference(&all, &vec![true; len]);
+
+            // All set, none of `right` set: output must be entirely false.
+            assert_matches_reference(&all, &vec![false; len]);
+
+            // A single set bit at the very end, the tail-handling case.
+            let mut last = vec![false; len];
+            last[len - 1] = true;
+            assert_matches_reference(&last, &[true]);
+            assert_matches_reference(&last, &[false]);
+        }
+    }
+
+    /// The documented shortcut: when every bit of `left` is set, the result is
+    /// `right` unchanged.
+    #[test]
+    fn and_then_returns_right_when_left_selects_everything() {
+        let left = buffer_of(&[true; 64]);
+        let right = buffer_of(&(0..64).map(|i| i % 5 == 0).collect::<Vec<_>>());
+
+        let result = boolean_buffer_and_then(&left, &right);
+
+        assert_eq!(result.len(), 64);
+        for i in 0..64 {
+            assert_eq!(result.value(i), right.value(i), "mismatch at {i}");
+        }
+    }
+
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_boolean_buffer_and_then_bmi2_large() {

--- a/src/datafusion/src/utils.rs
+++ b/src/datafusion/src/utils.rs
@@ -320,11 +320,14 @@ mod tests {
     /// aarch64, and on any x86_64 CPU without BMI2, since the fast path is
     /// chosen at runtime — would have no test of its own at all.
     ///
-    /// Both operands are assumed to start at bit 0. Neither implementation
-    /// handles a bit-offset (sliced) `left`, and they disagree with each other
-    /// on a bit-offset `right`; the sole caller only ever passes offset-0
-    /// buffers. Offset handling is tracked separately and is deliberately not
-    /// exercised here.
+    /// Both operands are assumed to start at bit 0, which is all the sole
+    /// caller ever passes. That limit is real and untested on purpose: the
+    /// fallback mishandles a bit-offset (sliced) `left`, because it seeds the
+    /// output from `left.values()` — which excludes the offset — while walking
+    /// the offset-aware `left.set_indices()`. The BMI2 path ignores the offset
+    /// of *both* operands, so the two disagree on a bit-offset `right`. Fixing
+    /// that means touching the filter hot path, so it is left to its own
+    /// change; covering it here would only pin down today's wrong answers.
     fn reference_and_then(left: &BooleanBuffer, right: &BooleanBuffer) -> Vec<bool> {
         debug_assert_eq!(left.offset(), 0);
         debug_assert_eq!(right.offset(), 0);


### PR DESCRIPTION
Makes the workspace build, test and run natively on macOS: all 9 t4 mount sites now go through one platform-aware `liquid_cache::store::mount` (byte-identical to `t4::mount` on Linux, buffered plus a one-time warning elsewhere), and `perf-event2` becomes a Linux-only dependency so the `benchmark` crate compiles. Adds a macOS CI job, gives `src/datafusion/src/utils.rs` its first aarch64 test coverage, and documents two things measurement depends on: buffered I/O means memory accounting understates residency off Linux, and FSST picks a different symbol table per architecture so compression ratios do not transfer between arm64 and x86_64.

Closes #12.
