### PR TITLE
fix(reader): refuse pushdown for unevaluable conjuncts

### DIFF
--- a/src/datafusion-local/src/tests/mod.rs
+++ b/src/datafusion-local/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod date_optimizer;
 mod filter_limit;
 mod page_index;
 mod squeeze;
+mod unevaluable_conjunct;
 mod variants;
 
 const TEST_FILE: &str = "../../examples/nano_hits.parquet";

--- a/src/datafusion-local/src/tests/unevaluable_conjunct.rs
+++ b/src/datafusion-local/src/tests/unevaluable_conjunct.rs
@@ -119,6 +119,73 @@ async fn nested_column_conjunct_is_still_applied() {
     }
 }
 
+/// Every conjunct being unevaluable was the case the old code thought was safe:
+/// it returned `None` only when *all* candidates failed. That was wrong too —
+/// `None` means the scan applies no filter at all, and the `FilterExec` that
+/// would have caught it is gone. `id > 100 OR st.a = 3` is a single conjunct
+/// touching `st`, so it takes that path, and it matches exactly one row.
+#[tokio::test]
+async fn sole_unevaluable_conjunct_is_still_applied() {
+    let dir = TempDir::new().unwrap();
+    let parquet = dir.path().join("t.parquet");
+    write_t(&parquet);
+    let ctx = liquid_ctx(&dir.path().join("cache")).await;
+    ctx.register_parquet(
+        "t",
+        parquet.to_str().unwrap(),
+        ParquetReadOptions::default(),
+    )
+    .await
+    .unwrap();
+
+    let sql = "SELECT id FROM t WHERE id > 100 OR st.a = 3";
+    for pass in ["cold", "warm"] {
+        assert_eq!(ids(&ctx, sql).await, vec![3], "{pass}");
+    }
+}
+
+/// Declining a scan costs it the cache, so the refusal has to stay narrow: it is
+/// a nested column *in the predicate* that the row filter cannot evaluate, not
+/// the mere presence of one in the table or in the projection. Projecting `st.a`
+/// is still cached, and so is a scan of a table that merely has a struct column.
+#[tokio::test]
+async fn only_a_nested_predicate_costs_the_cache() {
+    let dir = TempDir::new().unwrap();
+    let parquet = dir.path().join("t.parquet");
+    write_t(&parquet);
+    let ctx = liquid_ctx(&dir.path().join("cache")).await;
+    ctx.register_parquet(
+        "t",
+        parquet.to_str().unwrap(),
+        ParquetReadOptions::default(),
+    )
+    .await
+    .unwrap();
+
+    for sql in [
+        "SELECT st.a FROM t WHERE id >= 0",
+        "SELECT id FROM t WHERE id >= 0",
+        "SELECT id FROM t",
+    ] {
+        let plan = plan_of(&ctx, sql).await;
+        assert!(
+            plan.contains("liquid_parquet"),
+            "`{sql}` lost the cache; the refusal has widened:\n{plan}"
+        );
+    }
+
+    for sql in [
+        "SELECT id FROM t WHERE st.a = 3",
+        "SELECT id FROM t WHERE id >= 0 AND st.a = 3",
+    ] {
+        let plan = plan_of(&ctx, sql).await;
+        assert!(
+            !plan.contains("liquid_parquet"),
+            "`{sql}` kept a filter it cannot evaluate:\n{plan}"
+        );
+    }
+}
+
 /// The other `PushdownChecker` refusal: a conjunct on a column that is not in the
 /// file schema. The table declares `extra`, the file does not have it, so every
 /// row's `extra` is NULL and `extra = 3` is never TRUE.

--- a/src/datafusion-local/src/tests/unevaluable_conjunct.rs
+++ b/src/datafusion-local/src/tests/unevaluable_conjunct.rs
@@ -1,0 +1,160 @@
+//! Regression tests for issue #23 (and #21, one instance of it): a pushed-down
+//! conjunct the liquid row filter cannot evaluate.
+//!
+//! `build_row_filter` splits the pushed-down predicate into conjuncts and builds
+//! one `FilterCandidate` per conjunct. `PushdownChecker` refuses a conjunct that
+//! touches a nested column, and one that references a column absent from the
+//! file schema. Those refusals used to be dropped silently, leaving the scan
+//! applying a *strictly weaker* filter than the query asked for — and since
+//! DataFusion removes the `FilterExec` when it pushes a predicate down, nothing
+//! re-applies the dropped conjunct.
+//!
+//! The scan is now declined at plan time instead, so the predicate stays with
+//! the reader that planned it.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, Int32Array, Int64Array, RecordBatch, StructArray};
+use arrow_schema::{DataType, Field, Fields, Schema};
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::listing::{ListingOptions, ListingTableUrl};
+use datafusion::physical_plan::display::DisplayableExecutionPlan;
+use datafusion::prelude::{ParquetReadOptions, SessionConfig, SessionContext};
+use parquet::arrow::ArrowWriter;
+use tempfile::TempDir;
+
+use crate::LiquidCacheLocalBuilder;
+
+/// Eight rows: `id` 0..8, `st` a `struct<a int>` whose `a` mirrors `id`. Exactly
+/// one row has `st.a = 3`.
+fn write_t(path: &Path) {
+    let struct_fields = Fields::from(vec![Field::new("a", DataType::Int32, false)]);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("st", DataType::Struct(struct_fields.clone()), false),
+    ]));
+
+    let id: Int64Array = (0..8i64).collect::<Vec<_>>().into();
+    let a: ArrayRef = Arc::new((0..8i32).collect::<Int32Array>());
+    let st = StructArray::new(struct_fields, vec![a], None);
+
+    let batch =
+        RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(id), Arc::new(st)]).unwrap();
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+}
+
+async fn liquid_ctx(cache_dir: &Path) -> SessionContext {
+    std::fs::create_dir_all(cache_dir).unwrap();
+    let (ctx, _cache) = LiquidCacheLocalBuilder::new()
+        .with_cache_dir(cache_dir.to_path_buf())
+        .build(SessionConfig::new())
+        .await
+        .unwrap();
+    ctx
+}
+
+async fn ids(ctx: &SessionContext, sql: &str) -> Vec<i64> {
+    let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+    let mut out = Vec::new();
+    for batch in batches {
+        let column = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        out.extend(column.iter().map(|v| v.unwrap()));
+    }
+    out.sort_unstable();
+    out
+}
+
+async fn plan_of(ctx: &SessionContext, sql: &str) -> String {
+    let (state, plan) = ctx.sql(sql).await.unwrap().into_parts();
+    let plan = state.create_physical_plan(&plan).await.unwrap();
+    format!(
+        "{}",
+        DisplayableExecutionPlan::new(plan.as_ref()).indent(true)
+    )
+}
+
+/// The repro from #21: one conjunct is pushable (`id >= 0`, matching all eight
+/// rows) and one is not (`st.a = 3`, matching one). Dropping the second returned
+/// all eight rows.
+#[tokio::test]
+async fn nested_column_conjunct_is_still_applied() {
+    let dir = TempDir::new().unwrap();
+    let parquet = dir.path().join("t.parquet");
+    write_t(&parquet);
+    let ctx = liquid_ctx(&dir.path().join("cache")).await;
+    ctx.register_parquet(
+        "t",
+        parquet.to_str().unwrap(),
+        ParquetReadOptions::default(),
+    )
+    .await
+    .unwrap();
+
+    let sql = "SELECT id FROM t WHERE id >= 0 AND st.a = 3";
+
+    // The scan is declined rather than taken over with a filter that cannot
+    // evaluate `st.a`, so the plan still carries the whole predicate.
+    let plan = plan_of(&ctx, sql).await;
+    assert!(
+        plan.contains("id@0 >= 0 AND get_field(st@1, a) = 3"),
+        "the unevaluable conjunct left the plan:\n{plan}"
+    );
+    assert!(
+        !plan.contains("liquid_parquet"),
+        "the scan was taken over despite an unevaluable conjunct:\n{plan}"
+    );
+
+    // The first pass reads through the parquet fallback and would fill the cache;
+    // the second is served from it, a separate evaluation path.
+    for pass in ["cold", "warm"] {
+        assert_eq!(ids(&ctx, sql).await, vec![3], "{pass}");
+    }
+}
+
+/// The other `PushdownChecker` refusal: a conjunct on a column that is not in the
+/// file schema. The table declares `extra`, the file does not have it, so every
+/// row's `extra` is NULL and `extra = 3` is never TRUE.
+///
+/// The scan is still cached here — the opener's physical-expr adapter resolves
+/// `extra` to a literal NULL before the row filter is built, so nothing is
+/// dropped — but the answer has to come out right either way, and a filter that
+/// dropped the conjunct would return all eight rows.
+#[tokio::test]
+async fn conjunct_on_column_outside_file_schema_is_still_applied() {
+    let dir = TempDir::new().unwrap();
+    let table_dir = dir.path().join("t");
+    std::fs::create_dir_all(&table_dir).unwrap();
+    write_t(&table_dir.join("t.parquet"));
+    let ctx = liquid_ctx(&dir.path().join("cache")).await;
+
+    // A declared schema wider than the file: `extra` exists in the table schema
+    // only. `st` is left out so this test exercises the missing-column path alone.
+    let declared = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("extra", DataType::Int64, true),
+    ]));
+    let listing_options =
+        ListingOptions::new(Arc::new(ParquetFormat::default())).with_file_extension(".parquet");
+    ctx.register_listing_table(
+        "t",
+        &ListingTableUrl::parse(table_dir.to_str().unwrap()).unwrap(),
+        listing_options,
+        Some(declared),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let sql = "SELECT id FROM t WHERE id >= 0 AND extra = 3";
+    for pass in ["cold", "warm"] {
+        assert_eq!(ids(&ctx, sql).await, Vec::<i64>::new(), "{pass}");
+    }
+}

--- a/src/datafusion-server/src/tests/cases.rs
+++ b/src/datafusion-server/src/tests/cases.rs
@@ -26,6 +26,57 @@ fn gen_parquet(dir: impl AsRef<Path>) -> PathBuf {
     temp_path
 }
 
+/// Eight rows, `st` a `struct<a int>` mirroring `id`; one row has `st.a = 3`.
+fn gen_struct_parquet(dir: impl AsRef<Path>) -> PathBuf {
+    use arrow::array::{ArrayRef, Int32Array, Int64Array, StructArray};
+    use arrow::datatypes::{DataType, Field, Fields, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+
+    let temp_path = dir.as_ref().join("struct.parquet");
+    let struct_fields = Fields::from(vec![Field::new("a", DataType::Int32, false)]);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("st", DataType::Struct(struct_fields.clone()), false),
+    ]));
+
+    let id: ArrayRef = Arc::new((0..8i64).collect::<Int64Array>());
+    let a: ArrayRef = Arc::new((0..8i32).collect::<Int32Array>());
+    let st: ArrayRef = Arc::new(StructArray::new(struct_fields, vec![a], None));
+    let batch = RecordBatch::try_new(Arc::clone(&schema), vec![id, st]).unwrap();
+
+    let file = File::create(&temp_path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.into_inner().unwrap();
+    temp_path
+}
+
+/// Issue #23 on the server side. The client ships a fragment whose predicate is
+/// already fully pushed — the `FilterExec` was removed on the client, and the
+/// server cannot ask DataFusion to put one back — so `register_plan`'s rewrite is
+/// the only place the scan can be declined. Exercises that declined scans
+/// actually execute on the server, as vanilla parquet reads.
+#[tokio::test]
+async fn nested_column_conjunct_is_applied_on_the_server() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let file = gen_struct_parquet(&temp_dir);
+
+    // `id >= 0` matches all eight rows and `st.a = 3` matches one, so a dropped
+    // conjunct would show up as all eight ids coming back.
+    let result = run_sql(
+        "SELECT id FROM hits WHERE id >= 0 AND st.a = 3",
+        Box::new(TranscodeSqueezeEvict),
+        1000,
+        file.to_str().unwrap(),
+    )
+    .await;
+    assert_eq!(
+        result,
+        ["+----+", "| id |", "+----+", "| 3  |", "+----+"].join("\n")
+    );
+}
+
 #[tokio::test]
 async fn test_parquet_with_page_index() {
     let temp_dir = tempfile::tempdir().unwrap();

--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -28,7 +28,10 @@ use datafusion::{
 pub(crate) use squeeze_hint::HintAnalyzer;
 pub use squeeze_hint::SqueezeHintMap;
 
-use crate::{LiquidCacheParquetRef, LiquidParquetSource, cache::ColumnSqueezeHints};
+use crate::{
+    LiquidCacheParquetRef, LiquidParquetSource, cache::ColumnSqueezeHints,
+    reader::unevaluable_conjunct,
+};
 
 /// Parameters for the footprint-based admission gate.
 ///
@@ -547,6 +550,16 @@ fn file_required_bytes(
 
 /// If `node` is a `DataSourceExec` over a `ParquetSource`, return an equivalent
 /// node backed by [`LiquidParquetSource`] carrying `hints`.
+///
+/// Returns `None` — leaving the scan a vanilla parquet read — when the pushed-down
+/// predicate holds a conjunct the liquid row filter cannot evaluate. By the time
+/// this rule runs, DataFusion has already removed the `FilterExec` on the
+/// strength of `ParquetSource` accepting the whole predicate, so the scan is the
+/// only place it is applied. The liquid row filter is stricter than DataFusion's
+/// own (it refuses nested columns, which upstream handles), and it used to drop
+/// what it could not evaluate — running the scan with a strictly weaker filter
+/// than the query asked for (issues #21, #23). Declining the scan hands the
+/// predicate back to the reader that planned it, which applies all of it.
 fn convert_parquet_scan(
     node: &Arc<dyn ExecutionPlan>,
     cache: &LiquidCacheParquetRef,
@@ -555,6 +568,28 @@ fn convert_parquet_scan(
     let data_source_exec = node.downcast_ref::<DataSourceExec>()?;
     let (file_scan_config, parquet_source) =
         data_source_exec.downcast_to_file_source::<ParquetSource>()?;
+
+    if let Some(predicate) = parquet_source.filter() {
+        // Checked against the table schema, which is what the row filter
+        // effectively sees: the opener's physical-expr adapter resolves partition
+        // columns and columns missing from an individual file to literals before
+        // the filter is built. See `unevaluable_conjunct`.
+        let table_schema = parquet_source.table_schema().table_schema();
+        match unevaluable_conjunct(&predicate, table_schema) {
+            Ok(Some(conjunct)) => {
+                log::debug!(
+                    "Not caching scan: the liquid row filter cannot evaluate `{conjunct}`, \
+                     a conjunct of the pushed-down predicate `{predicate}`"
+                );
+                return None;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                log::debug!("Not caching scan: `{predicate}` could not be checked: {e}");
+                return None;
+            }
+        }
+    }
 
     let new_source =
         LiquidParquetSource::from_parquet_source(parquet_source.clone(), cache.clone())

--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -554,12 +554,32 @@ fn file_required_bytes(
 /// Returns `None` — leaving the scan a vanilla parquet read — when the pushed-down
 /// predicate holds a conjunct the liquid row filter cannot evaluate. By the time
 /// this rule runs, DataFusion has already removed the `FilterExec` on the
-/// strength of `ParquetSource` accepting the whole predicate, so the scan is the
-/// only place it is applied. The liquid row filter is stricter than DataFusion's
-/// own (it refuses nested columns, which upstream handles), and it used to drop
-/// what it could not evaluate — running the scan with a strictly weaker filter
-/// than the query asked for (issues #21, #23). Declining the scan hands the
-/// predicate back to the reader that planned it, which applies all of it.
+/// strength of `ParquetSource` accepting the whole predicate (both entry points
+/// force `execution.parquet.pushdown_filters`, so that removal always happens),
+/// and the scan is the only place the predicate is applied. The liquid row filter
+/// is stricter than DataFusion's own — it refuses nested columns, which upstream
+/// handles — and it used to drop what it could not evaluate, running the scan
+/// with a strictly weaker filter than the query asked for (issues #21, #23).
+/// Declining the scan hands the predicate back to the reader that planned it,
+/// which applies all of it.
+///
+/// Two things this is not, and why:
+///
+/// - **Not `FileSource::try_pushdown_filters`.** Declining per conjunct there is
+///   how DataFusion expects a source to say no, and it would keep the cache *and*
+///   leave a real `FilterExec`. It needs this rewrite to run before the
+///   `FilterPushdown` rule, and this rule cannot move: the admission gate sizes a
+///   scan from the pushed-down projection and predicate, neither of which exists
+///   that early, and the squeeze-hint analyzer reads the optimized plan. Splitting
+///   conversion from gating would fix local mode — but not the server, which
+///   receives a fragment whose `FilterExec` the *client* already removed. The
+///   server has no pushdown negotiation to join, so this gate is needed either way.
+/// - **Not teaching the row filter about nested columns.** Upstream evaluates
+///   `st.a = 3` by building a leaf-level `ProjectionMask` from struct field paths.
+///   Liquid masks by root (`ProjectionMask::roots`) and `get_predicate_column_id`
+///   reads the mask's leaf bits back as cache column ids, so a struct root — one
+///   column, several leaves — would address several cache entries. Lifting that
+///   means changing the cache's column-id model, well past a correctness fix.
 fn convert_parquet_scan(
     node: &Arc<dyn ExecutionPlan>,
     cache: &LiquidCacheParquetRef,
@@ -575,17 +595,20 @@ fn convert_parquet_scan(
         // columns and columns missing from an individual file to literals before
         // the filter is built. See `unevaluable_conjunct`.
         let table_schema = parquet_source.table_schema().table_schema();
+        // At `info`, like the admission gate's BYPASS line: this silently turns
+        // the cache off for a scan, and the only symptom is that queries stop
+        // getting faster.
         match unevaluable_conjunct(&predicate, table_schema) {
             Ok(Some(conjunct)) => {
-                log::debug!(
-                    "Not caching scan: the liquid row filter cannot evaluate `{conjunct}`, \
+                log::info!(
+                    "liquid_cache scan BYPASS: the row filter cannot evaluate `{conjunct}`, \
                      a conjunct of the pushed-down predicate `{predicate}`"
                 );
                 return None;
             }
             Ok(None) => {}
             Err(e) => {
-                log::debug!("Not caching scan: `{predicate}` could not be checked: {e}");
+                log::info!("liquid_cache scan BYPASS: `{predicate}` could not be checked: {e}");
                 return None;
             }
         }

--- a/src/datafusion/src/reader/mod.rs
+++ b/src/datafusion/src/reader/mod.rs
@@ -3,5 +3,6 @@ mod runtime;
 mod utils;
 pub(crate) mod variant_udf;
 
+pub(crate) use plantime::unevaluable_conjunct;
 pub use plantime::{FilterCandidateBuilder, LiquidParquetSource, LiquidPredicate, LiquidRowFilter};
 pub(crate) use runtime::extract_multi_column_or;

--- a/src/datafusion/src/reader/plantime/mod.rs
+++ b/src/datafusion/src/reader/plantime/mod.rs
@@ -8,4 +8,5 @@ mod row_filter;
 mod row_group_filter;
 mod source;
 
+pub(crate) use row_filter::unevaluable_conjunct;
 pub use row_filter::{FilterCandidateBuilder, LiquidPredicate, LiquidRowFilter};

--- a/src/datafusion/src/reader/plantime/opener.rs
+++ b/src/datafusion/src/reader/plantime/opener.rs
@@ -33,7 +33,6 @@ use datafusion::{
 };
 use futures::StreamExt;
 use futures::TryStreamExt;
-use log::debug;
 use parquet::arrow::{
     ParquetRecordBatchStreamBuilder, ProjectionMask,
     arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions},
@@ -230,25 +229,23 @@ impl FileOpener for LiquidParquetOpener {
             let indices = projection.column_indices();
             let mask = ProjectionMask::roots(builder.parquet_schema(), indices);
 
-            // Filter pushdown: evaluate predicates during scan
-            let row_filter = predicate.as_ref().and_then(|p| {
-                let row_filter = build_row_filter(
+            // Filter pushdown: evaluate predicates during scan.
+            //
+            // A failure here is not recoverable by ignoring it. DataFusion removed
+            // the `FilterExec` when it pushed this predicate down, so the row
+            // filter is the only place the predicate is applied; carrying on
+            // without one returns rows the query excluded. Fail the query instead
+            // (issue #23).
+            let row_filter = match predicate.as_ref() {
+                Some(p) => build_row_filter(
                     p,
                     &physical_file_schema,
                     reader_metadata.metadata(),
                     reorder_predicates,
                     &file_metrics,
-                );
-
-                match row_filter {
-                    Ok(Some(filter)) => Some(filter),
-                    Ok(None) => None,
-                    Err(e) => {
-                        debug!("Ignoring error building row filter for '{predicate:?}': {e:?}");
-                        None
-                    }
-                }
-            });
+                )?,
+                None => None,
+            };
 
             // Determine which row groups to actually read. The idea is to skip
             // as many row groups as possible based on the metadata and query

--- a/src/datafusion/src/reader/plantime/row_filter.rs
+++ b/src/datafusion/src/reader/plantime/row_filter.rs
@@ -79,6 +79,7 @@ use parquet::file::metadata::ParquetMetaData;
 
 use datafusion::common::Result;
 use datafusion::common::cast::as_boolean_array;
+use datafusion::common::internal_err;
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion, TreeNodeVisitor};
 use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::{PhysicalExpr, split_conjunction};
@@ -383,6 +384,35 @@ fn pushdown_columns(
     Ok((!checker.prevents_pushdown()).then_some(checker.required_columns.into_iter().collect()))
 }
 
+/// The first conjunct of `expr` the liquid row filter cannot evaluate against
+/// `schema`, if any.
+///
+/// This is the plan-time counterpart of the per-conjunct check
+/// [`build_row_filter`] performs at open time, and the two must agree: a scan
+/// whose predicate holds an unevaluable conjunct must never reach
+/// [`build_row_filter`], because by then DataFusion has removed the `FilterExec`
+/// and the scan is the only place the predicate is applied. See
+/// [`crate::optimizers::rewrite_data_source_plan`], which declines such a scan.
+///
+/// Pass the **table** schema, not the file schema. A column that is missing from
+/// an individual file, and a partition column, are both absent from the file
+/// schema but are turned into literals by the opener's physical-expr adapter
+/// before the row filter ever sees them — refusing on their account would
+/// needlessly bypass the cache. What genuinely cannot be evaluated is a
+/// reference to a nested column, or to a column that exists nowhere in the
+/// table.
+pub fn unevaluable_conjunct<'e>(
+    expr: &'e Arc<dyn PhysicalExpr>,
+    schema: &Schema,
+) -> Result<Option<&'e Arc<dyn PhysicalExpr>>> {
+    for conjunct in split_conjunction(expr) {
+        if pushdown_columns(conjunct, schema)?.is_none() {
+            return Ok(Some(conjunct));
+        }
+    }
+    Ok(None)
+}
+
 /// Calculate the total compressed size of all `Column`'s required for
 /// predicate `Expr`.
 ///
@@ -414,18 +444,22 @@ fn columns_sorted(_columns: &[usize], _metadata: &ParquetMetaData) -> Result<boo
 ///
 /// # returns
 /// * `Ok(Some(row_filter))` if the expression can be used as RowFilter
-/// * `Ok(None)` if the expression cannot be used as an RowFilter
+/// * `Ok(None)` if the expression holds no conjuncts at all
 /// * `Err(e)` if an error occurs while building the filter
 ///
-/// A conjunct that cannot be evaluated as an `ArrowPredicate` is dropped: given
-/// `a = 1 AND b = 2 AND c = 3` where `b = 2` cannot be evaluated, the returned
-/// filter holds `a = 1` and `c = 3`.
+/// Every conjunct must make it into the returned filter. Upstream DataFusion may
+/// drop a conjunct it cannot evaluate, because it only ever pushes down what it
+/// can evaluate and the `FilterExec` above it keeps the rest. Here the
+/// `FilterExec` is already gone by the time this runs — DataFusion removed it on
+/// the assumption the predicate was fully pushed — so this scan is the only place
+/// the predicate is applied, and a dropped conjunct *widens* the filter: rows
+/// that should not match come back (issues #19, #21, #23).
 ///
-/// That is a correctness hazard here, not the harmless narrowing it is upstream.
-/// DataFusion removes the `FilterExec` when it pushes a predicate down, so this
-/// scan is the only place the predicate is applied and a dropped conjunct widens
-/// the filter — rows that should not match come back. See issue #21; the honest
-/// fix is to refuse the pushdown so a `FilterExec` survives.
+/// Such a predicate is therefore kept off the liquid path at plan time, by
+/// [`crate::optimizers::rewrite_data_source_plan`], which leaves the scan as a
+/// vanilla parquet read so DataFusion applies the predicate itself. Reaching
+/// this function with an unevaluable conjunct means that gate and this builder
+/// have drifted apart, so it is an error rather than a silent narrowing.
 pub fn build_row_filter(
     expr: &Arc<dyn PhysicalExpr>,
     physical_file_schema: &SchemaRef,
@@ -440,6 +474,7 @@ pub fn build_row_filter(
     // Split into conjuncts:
     // `a = 1 AND b = 2 AND c = 3` -> [`a = 1`, `b = 2`, `c = 3`]
     let predicates = split_conjunction(expr);
+    let conjunct_count = predicates.len();
 
     // Determine which conjuncts can be evaluated as ArrowPredicates, if any
     let mut candidates: Vec<FilterCandidate> = predicates
@@ -452,6 +487,24 @@ pub fn build_row_filter(
         .into_iter()
         .flatten()
         .collect();
+
+    // One candidate per conjunct, or none of them can be trusted: see the note
+    // on this function. The plan-time gate should have kept such a predicate off
+    // this path entirely, so fail loudly rather than answer a weaker question
+    // than the one that was asked.
+    debug_assert_eq!(
+        candidates.len(),
+        conjunct_count,
+        "row filter dropped {} of {conjunct_count} conjuncts of `{expr}`",
+        conjunct_count - candidates.len()
+    );
+    if candidates.len() != conjunct_count {
+        return internal_err!(
+            "row filter can evaluate only {} of the {conjunct_count} conjuncts of `{expr}`; \
+             the scan is the only place this predicate is applied, so it cannot be pushed down",
+            candidates.len()
+        );
+    }
 
     // no candidates
     if candidates.is_empty() {
@@ -518,5 +571,128 @@ fn get_priority(expr: &Arc<dyn PhysicalExpr>) -> u8 {
         2 // LIKE expressions
     } else {
         6 // All other expression types
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int32Array, Int64Array, RecordBatch, StructArray};
+    use arrow_schema::{Field, Fields};
+    use datafusion::common::ScalarValue;
+    use datafusion::physical_plan::expressions::{BinaryExpr, Column, Literal};
+    use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+    use parquet::arrow::ArrowWriter;
+    use parquet::arrow::arrow_reader::ArrowReaderMetadata;
+
+    fn col(name: &str, index: usize) -> Arc<dyn PhysicalExpr> {
+        Arc::new(Column::new(name, index))
+    }
+
+    fn eq(left: Arc<dyn PhysicalExpr>, right: i64) -> Arc<dyn PhysicalExpr> {
+        Arc::new(BinaryExpr::new(
+            left,
+            Operator::Eq,
+            Arc::new(Literal::new(ScalarValue::Int64(Some(right)))),
+        ))
+    }
+
+    fn and(left: Arc<dyn PhysicalExpr>, right: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
+        Arc::new(BinaryExpr::new(left, Operator::And, right))
+    }
+
+    /// `id int64` plus `st struct<a int32>`, the shape from the issue.
+    fn schema_with_struct() -> Schema {
+        Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "st",
+                DataType::Struct(Fields::from(vec![Field::new("a", DataType::Int32, false)])),
+                false,
+            ),
+        ])
+    }
+
+    /// A one-row parquet file over `schema_with_struct`, and its metadata.
+    fn metadata() -> (SchemaRef, ParquetMetaData) {
+        let schema = Arc::new(schema_with_struct());
+        let fields = Fields::from(vec![Field::new("a", DataType::Int32, false)]);
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(vec![1])),
+                Arc::new(StructArray::new(
+                    fields,
+                    vec![Arc::new(Int32Array::from(vec![1]))],
+                    None,
+                )),
+            ],
+        )
+        .unwrap();
+
+        let mut buffer = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buffer, Arc::clone(&schema), None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let bytes = bytes::Bytes::from(buffer);
+        let reader = ArrowReaderMetadata::load(&bytes, Default::default()).unwrap();
+        let metadata = Arc::try_unwrap(Arc::clone(reader.metadata()))
+            .unwrap_or_else(|shared| shared.as_ref().clone());
+        (schema, metadata)
+    }
+
+    /// `PushdownChecker`'s `non_primitive_columns` path: `st` is a struct, so no
+    /// conjunct that reads it can be evaluated as an `ArrowPredicate`.
+    #[test]
+    fn nested_column_conjunct_is_unevaluable() {
+        let schema = schema_with_struct();
+        let nested = eq(col("st", 1), 3);
+        let expr = and(eq(col("id", 0), 0), Arc::clone(&nested));
+
+        let found = unevaluable_conjunct(&expr, &schema).unwrap();
+        assert!(Arc::ptr_eq(found.unwrap(), &nested));
+    }
+
+    /// `PushdownChecker`'s `projected_columns` path: `missing` is in no schema the
+    /// scan can read.
+    #[test]
+    fn conjunct_on_column_outside_schema_is_unevaluable() {
+        let schema = schema_with_struct();
+        let absent = eq(col("missing", 2), 3);
+        let expr = and(eq(col("id", 0), 0), Arc::clone(&absent));
+
+        let found = unevaluable_conjunct(&expr, &schema).unwrap();
+        assert!(Arc::ptr_eq(found.unwrap(), &absent));
+    }
+
+    /// A predicate every conjunct of which reads a primitive column of the schema
+    /// is evaluable, so the scan is not declined for it.
+    #[test]
+    fn primitive_conjuncts_are_evaluable() {
+        let schema = schema_with_struct();
+        let expr = and(eq(col("id", 0), 0), eq(col("id", 0), 3));
+
+        assert!(unevaluable_conjunct(&expr, &schema).unwrap().is_none());
+    }
+
+    /// The invariant behind the plan-time gate: reaching the builder with a
+    /// conjunct it cannot evaluate is a bug, not a licence to narrow the filter.
+    /// A debug build trips the assertion; a release build returns the error.
+    #[test]
+    #[cfg_attr(debug_assertions, should_panic(expected = "row filter dropped"))]
+    fn build_row_filter_refuses_to_drop_a_conjunct() {
+        let (schema, metadata) = metadata();
+        let expr = and(eq(col("id", 0), 0), eq(col("st", 1), 3));
+        let metrics = ExecutionPlanMetricsSet::new();
+        let file_metrics = ParquetFileMetrics::new(0, "test.parquet", &metrics);
+
+        let Err(err) = build_row_filter(&expr, &schema, &metadata, false, &file_metrics) else {
+            panic!("a dropped conjunct must not be reported as a usable filter");
+        };
+        assert!(
+            err.to_string().contains("cannot be pushed down"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
A conjunct the liquid row filter cannot evaluate now declines the scan at plan time — leaving it a vanilla parquet read, so DataFusion applies the whole predicate — instead of being dropped from a filter that is the only place the predicate is applied.

Note on #23's first acceptance bullet: no `FilterExec` survives, because none can. `build_row_filter` runs in the opener at execution time, long after `FilterPushdown` removed it, so refusing there would leave the scan with no filter at all. The decision had to move to plan time, where declining the scan is the available lever — and it is the only lever in server mode, where the client removed the `FilterExec` before shipping the fragment.

Follow-ups: #39 (evaluate nested conjuncts instead of declining, which would remove the cache loss this introduces), blocked on #38 (a live bug this review turned up: predicate column ids are parquet leaf positions but read as file-schema field indices).

Closes #21
Closes #23
