### PR TITLE
fix(optimizer): keep scans that need virtual columns on ParquetSource

### DIFF
--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -19,6 +19,7 @@ use datafusion::{
         listing::PartitionedFile,
         physical_plan::{FileScanConfig, FileSource, ParquetSource},
         source::DataSource,
+        table_schema::TableSchema,
     },
     physical_expr::utils::collect_columns,
     physical_optimizer::{PhysicalOptimizerRule, pruning::PruningPredicateBuilder},
@@ -551,6 +552,33 @@ fn file_required_bytes(
     (sum, false)
 }
 
+/// The scan's virtual columns as a display list, when it declares any.
+///
+/// The liquid read path has no notion of DataFusion's virtual columns. It carries
+/// the [`TableSchema`] across faithfully but never produces one, so a scan that
+/// projects a virtual column reads back a batch which simply lacks it. Such a scan
+/// has to stay on `ParquetSource`, which derives virtual columns from the parquet
+/// reader.
+///
+/// Positional reads are the case that reaches here: delete filtering and row
+/// lineage both project a reader-produced physical row-position column, and that
+/// position is an absolute index into the file. Emitting a plausible but shifted
+/// position would apply a delete to the wrong row, so declining the swap is the
+/// only sound answer while the liquid reader cannot generate one itself.
+fn unproducible_virtual_columns(table_schema: &TableSchema) -> Option<String> {
+    let virtual_columns = table_schema.virtual_columns();
+    if virtual_columns.is_empty() {
+        return None;
+    }
+    Some(
+        virtual_columns
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>()
+            .join("`, `"),
+    )
+}
+
 /// If `node` is a `DataSourceExec` over a `ParquetSource`, return an equivalent
 /// node backed by [`LiquidParquetSource`] carrying `hints`.
 ///
@@ -617,6 +645,13 @@ fn convert_parquet_scan(
         }
     }
 
+    if let Some(names) = unproducible_virtual_columns(parquet_source.table_schema()) {
+        log::info!(
+            "liquid_cache scan BYPASS: the read path cannot produce virtual column(s) `{names}`"
+        );
+        return None;
+    }
+
     let new_source =
         LiquidParquetSource::from_parquet_source(parquet_source.clone(), cache.clone())
             .with_squeeze_hints(Arc::new(hints));
@@ -638,6 +673,37 @@ mod tests {
     use crate::LiquidCacheParquet;
 
     use super::*;
+
+    /// A scan whose `TableSchema` declares a virtual column must not be moved onto
+    /// the liquid source: the liquid read path never produces one, so the projected
+    /// column would come back missing and the scan would fail to resolve it. Pure
+    /// schema inspection, so this runs everywhere — no cache and no mount.
+    #[test]
+    fn virtual_columns_are_reported_as_unproducible() {
+        use arrow_schema::{DataType, Field, Fields};
+
+        let file_schema = Arc::new(arrow_schema::Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("val", DataType::Int64, true),
+        ]));
+
+        // An ordinary scan declares none, and stays eligible for the cache.
+        let plain = TableSchema::builder(Arc::clone(&file_schema)).build();
+        assert_eq!(unproducible_virtual_columns(&plain), None);
+
+        // A positional scan appends the reader-produced row-position column.
+        let positional = TableSchema::builder(file_schema)
+            .with_virtual_columns(Fields::from(vec![Field::new(
+                "__ducklake_row_pos",
+                DataType::Int64,
+                true,
+            )]))
+            .build();
+        assert_eq!(
+            unproducible_virtual_columns(&positional).as_deref(),
+            Some("__ducklake_row_pos"),
+        );
+    }
 
     async fn rewrite_plan_inner(plan: Arc<dyn ExecutionPlan>) {
         let expected_schema = plan.schema();

--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -21,7 +21,7 @@ use datafusion::{
         source::DataSource,
         table_schema::TableSchema,
     },
-    physical_expr::utils::collect_columns,
+    physical_expr::{projection::ProjectionExprs, utils::collect_columns},
     physical_optimizer::{PhysicalOptimizerRule, pruning::PruningPredicateBuilder},
     physical_plan::ExecutionPlan,
 };
@@ -552,31 +552,57 @@ fn file_required_bytes(
     (sum, false)
 }
 
-/// The scan's virtual columns as a display list, when it declares any.
+/// The virtual columns this scan reads that the liquid path cannot produce.
 ///
 /// The liquid read path has no notion of DataFusion's virtual columns. It carries
 /// the [`TableSchema`] across faithfully but never produces one, so a scan that
-/// projects a virtual column reads back a batch which simply lacks it. Such a scan
-/// has to stay on `ParquetSource`, which derives virtual columns from the parquet
+/// reads a virtual column gets back a batch which simply lacks it. Such a scan has
+/// to stay on `ParquetSource`, which derives virtual columns from the parquet
 /// reader.
 ///
-/// Positional reads are the case that reaches here: delete filtering and row
-/// lineage both project a reader-produced physical row-position column, and that
-/// position is an absolute index into the file. Emitting a plausible but shifted
-/// position would apply a delete to the wrong row, so declining the swap is the
-/// only sound answer while the liquid reader cannot generate one itself.
-fn unproducible_virtual_columns(table_schema: &TableSchema) -> Option<String> {
+/// Declining a scan costs it the cache, so this stays as narrow as the row
+/// filter's own refusal: a virtual column the scan actually reads, not the mere
+/// presence of one on the table. A provider that declares a row-position column on
+/// every table keeps the cache for the queries that never project it. No
+/// projection at all is the one broad case, and it is not a guess — the scan then
+/// reads the whole table schema, virtual columns included.
+///
+/// Positional reads are what reaches here: applying positional deletes, and row
+/// lineage, both project a reader-produced physical row position, which is an
+/// absolute index into the file. A plausible but shifted position would associate
+/// a delete with the wrong row, so declining is the sound answer while the liquid
+/// reader cannot generate positions itself.
+fn unproducible_virtual_columns(
+    table_schema: &TableSchema,
+    projection: Option<&ProjectionExprs>,
+) -> Option<String> {
     let virtual_columns = table_schema.virtual_columns();
     if virtual_columns.is_empty() {
         return None;
     }
-    Some(
-        virtual_columns
-            .iter()
-            .map(|field| field.name().as_str())
-            .collect::<Vec<_>>()
-            .join("`, `"),
-    )
+
+    let mut needed: Vec<&str> = Vec::new();
+    match projection {
+        None => needed.extend(virtual_columns.iter().map(|field| field.name().as_str())),
+        Some(projection) => {
+            let read: HashSet<String> = projection
+                .expr_iter()
+                .flat_map(|expr| collect_columns(&expr))
+                .map(|column| column.name().to_string())
+                .collect();
+            needed.extend(
+                virtual_columns
+                    .iter()
+                    .map(|field| field.name().as_str())
+                    .filter(|name| read.contains(*name)),
+            );
+        }
+    }
+
+    if needed.is_empty() {
+        return None;
+    }
+    Some(needed.join("`, `"))
 }
 
 /// If `node` is a `DataSourceExec` over a `ParquetSource`, return an equivalent
@@ -645,7 +671,9 @@ fn convert_parquet_scan(
         }
     }
 
-    if let Some(names) = unproducible_virtual_columns(parquet_source.table_schema()) {
+    if let Some(names) =
+        unproducible_virtual_columns(parquet_source.table_schema(), parquet_source.projection())
+    {
         log::info!(
             "liquid_cache scan BYPASS: the read path cannot produce virtual column(s) `{names}`"
         );
@@ -674,34 +702,102 @@ mod tests {
 
     use super::*;
 
-    /// A scan whose `TableSchema` declares a virtual column must not be moved onto
-    /// the liquid source: the liquid read path never produces one, so the projected
-    /// column would come back missing and the scan would fail to resolve it. Pure
-    /// schema inspection, so this runs everywhere — no cache and no mount.
+    /// Declining a scan costs it the cache, so the guard must key on what the scan
+    /// reads, not on what the table declares. A row-position column present on the
+    /// table but absent from the projection keeps the cache; no projection at all
+    /// reads the whole table schema and does not.
     #[test]
-    fn virtual_columns_are_reported_as_unproducible() {
+    fn only_a_virtual_column_the_scan_reads_costs_the_cache() {
         use arrow_schema::{DataType, Field, Fields};
+        use datafusion::physical_expr::expressions::col;
+        use datafusion::physical_expr::projection::ProjectionExpr;
 
         let file_schema = Arc::new(arrow_schema::Schema::new(vec![
             Field::new("id", DataType::Int64, false),
             Field::new("val", DataType::Int64, true),
         ]));
+        let row_pos = Field::new("__ducklake_row_pos", DataType::Int64, true);
 
-        // An ordinary scan declares none, and stays eligible for the cache.
+        // No virtual columns at all: nothing to refuse, whatever the projection.
         let plain = TableSchema::builder(Arc::clone(&file_schema)).build();
-        assert_eq!(unproducible_virtual_columns(&plain), None);
+        assert_eq!(unproducible_virtual_columns(&plain, None), None);
 
-        // A positional scan appends the reader-produced row-position column.
-        let positional = TableSchema::builder(file_schema)
-            .with_virtual_columns(Fields::from(vec![Field::new(
-                "__ducklake_row_pos",
-                DataType::Int64,
-                true,
-            )]))
+        let positional = TableSchema::builder(Arc::clone(&file_schema))
+            .with_virtual_columns(Fields::from(vec![row_pos.clone()]))
             .build();
+        let full = positional.table_schema();
+
+        // Declared but not read: still cached.
+        let only_id =
+            ProjectionExprs::new(vec![ProjectionExpr::new(col("id", full).unwrap(), "id")]);
         assert_eq!(
-            unproducible_virtual_columns(&positional).as_deref(),
-            Some("__ducklake_row_pos"),
+            unproducible_virtual_columns(&positional, Some(&only_id)),
+            None
+        );
+
+        // Read: refused, and named.
+        let reads_pos = ProjectionExprs::new(vec![ProjectionExpr::new(
+            col("__ducklake_row_pos", full).unwrap(),
+            "__ducklake_row_pos",
+        )]);
+        assert_eq!(
+            unproducible_virtual_columns(&positional, Some(&reads_pos)).as_deref(),
+            Some("__ducklake_row_pos")
+        );
+
+        // No projection reads the whole table schema, virtual columns included.
+        assert_eq!(
+            unproducible_virtual_columns(&positional, None).as_deref(),
+            Some("__ducklake_row_pos")
+        );
+    }
+
+    /// The guard has to hold at the call site, not only in the helper, so that
+    /// removing the bypass from `convert_parquet_scan` fails a test rather than
+    /// silently restoring the broken plan.
+    #[tokio::test]
+    async fn a_scan_reading_a_virtual_column_stays_on_parquet_source() {
+        use arrow_schema::{DataType, Field, Fields};
+        use datafusion::datasource::physical_plan::FileScanConfigBuilder;
+        use datafusion::execution::object_store::ObjectStoreUrl;
+
+        let file_schema = Arc::new(arrow_schema::Schema::new(vec![Field::new(
+            "id",
+            DataType::Int64,
+            false,
+        )]));
+
+        let scan = |table_schema: TableSchema| -> Arc<dyn ExecutionPlan> {
+            let source = Arc::new(ParquetSource::new(table_schema)) as Arc<dyn FileSource>;
+            let config = FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), source)
+                .with_file(PartitionedFile::new("t.parquet", 16))
+                .build();
+            Arc::new(DataSourceExec::new(Arc::new(config)))
+        };
+
+        let cache = build_cache().await;
+
+        // Positive control: an ordinary scan is still handed to the cache.
+        let plain = scan(TableSchema::builder(Arc::clone(&file_schema)).build());
+        assert!(
+            convert_parquet_scan(&plain, &cache, ColumnSqueezeHints::default()).is_some(),
+            "an ordinary scan must still convert to the liquid source"
+        );
+
+        // `ParquetSource::new` projects the whole table schema, so the positional
+        // scan reads the row-position column and cannot be served.
+        let positional = scan(
+            TableSchema::builder(file_schema)
+                .with_virtual_columns(Fields::from(vec![Field::new(
+                    "__ducklake_row_pos",
+                    DataType::Int64,
+                    true,
+                )]))
+                .build(),
+        );
+        assert!(
+            convert_parquet_scan(&positional, &cache, ColumnSqueezeHints::default()).is_none(),
+            "a scan reading a virtual column must stay on ParquetSource"
         );
     }
 

--- a/src/datafusion/src/optimizers/mod.rs
+++ b/src/datafusion/src/optimizers/mod.rs
@@ -21,7 +21,7 @@ use datafusion::{
         source::DataSource,
         table_schema::TableSchema,
     },
-    physical_expr::{projection::ProjectionExprs, utils::collect_columns},
+    physical_expr::{PhysicalExpr, projection::ProjectionExprs, utils::collect_columns},
     physical_optimizer::{PhysicalOptimizerRule, pruning::PruningPredicateBuilder},
     physical_plan::ExecutionPlan,
 };
@@ -556,7 +556,8 @@ fn file_required_bytes(
 ///
 /// The liquid read path has no notion of DataFusion's virtual columns. It carries
 /// the [`TableSchema`] across faithfully but never produces one, so a scan that
-/// reads a virtual column gets back a batch which simply lacks it. Such a scan has
+/// reads a virtual column gets back a batch which simply lacks it, and a predicate
+/// over one cannot be rewritten against the file schemas either. Such a scan has
 /// to stay on `ParquetSource`, which derives virtual columns from the parquet
 /// reader.
 ///
@@ -575,6 +576,7 @@ fn file_required_bytes(
 fn unproducible_virtual_columns(
     table_schema: &TableSchema,
     projection: Option<&ProjectionExprs>,
+    filter: Option<&Arc<dyn PhysicalExpr>>,
 ) -> Option<String> {
     let virtual_columns = table_schema.virtual_columns();
     if virtual_columns.is_empty() {
@@ -585,11 +587,23 @@ fn unproducible_virtual_columns(
     match projection {
         None => needed.extend(virtual_columns.iter().map(|field| field.name().as_str())),
         Some(projection) => {
-            let read: HashSet<String> = projection
+            let mut read: HashSet<String> = projection
                 .expr_iter()
                 .flat_map(|expr| collect_columns(&expr))
                 .map(|column| column.name().to_string())
                 .collect();
+            // The pushed-down predicate is rewritten against the file schemas in
+            // the opener too, so a conjunct over a virtual column fails exactly as
+            // a projection over one does. The row filter's own check cannot catch
+            // it: that resolves against the table schema, which does hold the
+            // virtual columns.
+            if let Some(filter) = filter {
+                read.extend(
+                    collect_columns(filter)
+                        .into_iter()
+                        .map(|column| column.name().to_string()),
+                );
+            }
             needed.extend(
                 virtual_columns
                     .iter()
@@ -671,9 +685,12 @@ fn convert_parquet_scan(
         }
     }
 
-    if let Some(names) =
-        unproducible_virtual_columns(parquet_source.table_schema(), parquet_source.projection())
-    {
+    let pushed_filter = parquet_source.filter();
+    if let Some(names) = unproducible_virtual_columns(
+        parquet_source.table_schema(),
+        parquet_source.projection(),
+        pushed_filter.as_ref(),
+    ) {
         log::info!(
             "liquid_cache scan BYPASS: the read path cannot produce virtual column(s) `{names}`"
         );
@@ -709,7 +726,8 @@ mod tests {
     #[test]
     fn only_a_virtual_column_the_scan_reads_costs_the_cache() {
         use arrow_schema::{DataType, Field, Fields};
-        use datafusion::physical_expr::expressions::col;
+        use datafusion::logical_expr::Operator;
+        use datafusion::physical_expr::expressions::{BinaryExpr, col, lit};
         use datafusion::physical_expr::projection::ProjectionExpr;
 
         let file_schema = Arc::new(arrow_schema::Schema::new(vec![
@@ -720,7 +738,7 @@ mod tests {
 
         // No virtual columns at all: nothing to refuse, whatever the projection.
         let plain = TableSchema::builder(Arc::clone(&file_schema)).build();
-        assert_eq!(unproducible_virtual_columns(&plain, None), None);
+        assert_eq!(unproducible_virtual_columns(&plain, None, None), None);
 
         let positional = TableSchema::builder(Arc::clone(&file_schema))
             .with_virtual_columns(Fields::from(vec![row_pos.clone()]))
@@ -731,7 +749,7 @@ mod tests {
         let only_id =
             ProjectionExprs::new(vec![ProjectionExpr::new(col("id", full).unwrap(), "id")]);
         assert_eq!(
-            unproducible_virtual_columns(&positional, Some(&only_id)),
+            unproducible_virtual_columns(&positional, Some(&only_id), None),
             None
         );
 
@@ -741,13 +759,27 @@ mod tests {
             "__ducklake_row_pos",
         )]);
         assert_eq!(
-            unproducible_virtual_columns(&positional, Some(&reads_pos)).as_deref(),
+            unproducible_virtual_columns(&positional, Some(&reads_pos), None).as_deref(),
             Some("__ducklake_row_pos")
         );
 
         // No projection reads the whole table schema, virtual columns included.
         assert_eq!(
-            unproducible_virtual_columns(&positional, None).as_deref(),
+            unproducible_virtual_columns(&positional, None, None).as_deref(),
+            Some("__ducklake_row_pos")
+        );
+
+        // Read only by the pushed-down predicate: refused too. The opener rewrites
+        // the predicate against the file schemas as well, and the row filter's own
+        // check passes it because that resolves against the table schema.
+        let pos_predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            col("__ducklake_row_pos", full).unwrap(),
+            Operator::Gt,
+            lit(0i64),
+        ));
+        assert_eq!(
+            unproducible_virtual_columns(&positional, Some(&only_id), Some(&pos_predicate))
+                .as_deref(),
             Some("__ducklake_row_pos")
         );
     }


### PR DESCRIPTION
## Problem

The liquid read path has no notion of DataFusion's virtual columns. `TableSchema` supports
them (`TableSchema::builder(..).with_virtual_columns(..)`), and `ParquetSource` derives them
from the parquet reader. `LiquidParquetSource` carries the `TableSchema` across faithfully,
but nothing in the liquid read path ever *produces* a virtual column — `grep -c virtual` over
`reader/plantime/{source,opener}.rs` returns 0.

So when a scan's projection includes a virtual column, the batch comes back without it and
resolving the column fails:

```
Arrow error: Schema error: Unable to get field named "<virtual column>".
Valid fields: [... the file's own columns ...]
```

The error surfaces from DataFusion's `DefaultPhysicalExprAdapter`, on the branch whose own
comment reads *"A completely unknown column that doesn't exist in either schema! This should
probably never be hit unless something upstream broke."*

Table formats layered on DataFusion hit this. A DuckLake positional read is the concrete
case: applying positional deletes projects a reader-produced physical row-position column and
nothing else, so every read of an affected table fails while the cache is enabled. Confirmed
by A/B: the same query on the same file succeeds with `file_type=parquet` and fails with
`file_type=liquid_parquet`.

## Fix

Decline the conversion for such scans, leaving them on `ParquetSource`.

This mirrors the BYPASS already in `convert_parquet_scan` for predicates the liquid row
filter cannot evaluate — same shape, same `log::info!` level, and it names the columns so the
reason is visible rather than showing up only as "queries stopped getting faster".

Why decline rather than pass the column through: there is nothing to pass through. The value
never exists, because the liquid reader replaces the parquet reader that would have generated
it. Producing it properly is follow-up work, and it is not trivial — the position must be the
row's **absolute physical index in the file**, and must stay correct under row-group pruning,
selection pushdown, and cache hits that never touch the parquet file at all. A position that
is plausible but shifted would associate a delete with the wrong row, which is strictly worse
than the current loud failure.

## Scope

The guard keys on the virtual columns the scan **reads** — via its projection *and* its
pushed-down predicate — not on what the table declares, so it stays as narrow as the row
filter's own refusal:

- an ordinary scan declares none and still converts — `test_plan_rewrite` passes unchanged,
  and the new call-site test asserts it explicitly as a positive control;
- a table that declares a row-position column keeps the cache for every query that neither
  projects nor filters on it;
- no projection at all is refused, and that is not a guess: the scan then reads the whole
  table schema, virtual columns included.

The cost is that a scan actually reading a virtual column loses cache acceleration. Those
scans fail outright today, so this is strictly an improvement for them. For a DuckLake table
the refusal also lifts on its own once compaction purges the delete files that made reads
positional.

## Testing

`cargo test -p liquid-cache-datafusion` — 74 passed, 0 failed, plus doc-tests. `cargo fmt
--check` and `cargo clippy --all-targets` clean.

Two tests, neither of which passes if the bypass is removed:

- `only_a_virtual_column_the_scan_reads_costs_the_cache` — covers declared-and-read,
  declared-but-not-read, no-projection, and read-only-by-the-predicate. Pure schema
  inspection, no cache or mount, so it runs everywhere.
- `a_scan_reading_a_virtual_column_stays_on_parquet_source` — asserts at the
  `convert_parquet_scan` call site, with an ordinary scan as a positive control.

Note for anyone building this repo: there is no `rust-toolchain.toml`, and datafusion 55
requires rustc >= 1.94, so a default stable older than that fails to resolve dependencies.
